### PR TITLE
[#35] fix feed selector inverted on estop

### DIFF
--- a/src/components/Feed/Feed.tsx
+++ b/src/components/Feed/Feed.tsx
@@ -37,7 +37,7 @@ export const Feed: FC<FeedProps> = ({ id, defaultFeed }) => {
       onMouseOver={onOver}
     >
       <FeedView feed={feed} />
-      <FeedSelect id={id} visible={!isMouseOver} currentFeedId={feed.id} />
+      <FeedSelect id={id} visible={isMouseOver} currentFeedId={feed.id} />
     </StyledFeedComponent>
   )
 }

--- a/src/components/Feed/Feed.tsx
+++ b/src/components/Feed/Feed.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState, useMemo } from 'react'
+import React, { FC, useMemo } from 'react'
 import { useSelector } from 'utils/hooks/typedUseSelector'
 import { StyledFeedComponent } from 'components/Feed/Feed.styles'
 import {
@@ -7,6 +7,7 @@ import {
 } from 'store/modules/feed/reducer'
 import { FeedSelect } from 'components/Feed/FeedSelect'
 import { FeedView } from 'components/Feed/FeedView'
+import { useOpenClose } from 'utils/hooks/useOpenClose'
 
 interface FeedProps {
   id: string
@@ -14,8 +15,7 @@ interface FeedProps {
 }
 
 export const Feed: FC<FeedProps> = ({ id, defaultFeed }) => {
-  const [hover, setHover] = useState(false)
-  const toggleHover = () => setHover(!hover)
+  const [isMouseOver, onOver, onLeave] = useOpenClose()
 
   const mappedFeed = useSelector(selectFeedFromFeedMap(id))
   const allFeeds = useSelector(selectAllFeeds)
@@ -31,9 +31,13 @@ export const Feed: FC<FeedProps> = ({ id, defaultFeed }) => {
   }, [allFeeds, defaultFeed, mappedFeed])
 
   return (
-    <StyledFeedComponent onMouseEnter={toggleHover} onMouseLeave={toggleHover}>
+    <StyledFeedComponent
+      onMouseEnter={onOver}
+      onMouseLeave={onLeave}
+      onMouseOver={onOver}
+    >
       <FeedView feed={feed} />
-      <FeedSelect id={id} visible={!hover} currentFeedId={feed.id} />
+      <FeedSelect id={id} visible={!isMouseOver} currentFeedId={feed.id} />
     </StyledFeedComponent>
   )
 }

--- a/src/components/Feed/FeedSelect.tsx
+++ b/src/components/Feed/FeedSelect.tsx
@@ -29,7 +29,7 @@ export const FeedSelect: FC<FeedSelectProps> = ({
     <StyledFeedSelect
       onChange={selectFeed}
       value={currentFeedId}
-      hidden={visible}
+      hidden={!visible}
     >
       {feedCollection.map(feed => (
         <option key={feed.id} value={feed.id}>

--- a/src/utils/hooks/useOpenClose.ts
+++ b/src/utils/hooks/useOpenClose.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 
 export const useOpenClose = (
-  defaultIsOpen: boolean = false
+  defaultIsOpen = false
 ): [boolean, () => void, () => void, () => void] => {
   const [isOpen, setIsOpen] = useState(defaultIsOpen)
   const onClose = () => setIsOpen(false)


### PR DESCRIPTION
closes #35 

The visibility status was toggled on mouse leave, but since the mouse is already over the feed it never triggered the onMouseEnter callback.