### PR TITLE
Tweak arm controls to improve usability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capra_web_ui",
-  "version": "2.4.9",
+  "version": "2.4.10",
   "author": {
     "name": "Club Capra",
     "email": "admin@clubcapra.com",

--- a/src/renderer/inputSystem/armModeActions.ts
+++ b/src/renderer/inputSystem/armModeActions.ts
@@ -13,6 +13,8 @@ import { handleTpvControl } from './tpvControl'
 const jointGoalTopic: TopicOptions = {
   name: 'ovis/arm/in/joint_velocity_goal',
   messageType: 'ovis_msgs/OvisArmJointVelocity',
+  queue_size: 1,
+  queue_length: 1,
 }
 
 export const armModeActions: Action[] = [
@@ -72,7 +74,7 @@ export const armModeActions: Action[] = [
 
       const gamepad = ctx.gamepadState.gamepad
       if (armService.state.matches('joint')) {
-        if (gamepad.buttons[buttonMappings.A].pressed) {
+        if (deadzone(gamepad.axes[sticks.left.vertical]) !== 0) {
           rosClient.publish(jointGoalTopic, {
             joint_index: (armService.state.context as ArmContext).jointValue,
             joint_velocity: -deadzone(gamepad.axes[sticks.left.vertical]),

--- a/src/renderer/inputSystem/armModeActions.ts
+++ b/src/renderer/inputSystem/armModeActions.ts
@@ -13,8 +13,6 @@ import { handleTpvControl } from './tpvControl'
 const jointGoalTopic: TopicOptions = {
   name: 'ovis/arm/in/joint_velocity_goal',
   messageType: 'ovis_msgs/OvisArmJointVelocity',
-  queue_size: 1,
-  queue_length: 1,
 }
 
 export const armModeActions: Action[] = [

--- a/src/renderer/inputSystem/armModeActions.ts
+++ b/src/renderer/inputSystem/armModeActions.ts
@@ -77,7 +77,7 @@ export const armModeActions: Action[] = [
         if (deadzone(gamepad.axes[sticks.left.vertical]) !== 0) {
           rosClient.publish(jointGoalTopic, {
             joint_index: (armService.state.context as ArmContext).jointValue,
-            joint_velocity: -deadzone(gamepad.axes[sticks.left.vertical]),
+            joint_velocity: -gamepad.axes[sticks.left.vertical],
           })
         }
       }

--- a/src/renderer/utils/gamepad/index.ts
+++ b/src/renderer/utils/gamepad/index.ts
@@ -4,7 +4,7 @@ import { Vector3 } from '@/renderer/utils/math/types'
 import { store } from '@/renderer/store/store'
 
 export const deadzone = (value: number): number => {
-  const deadzone = 0.15
+  const deadzone = 0.1
   return value > deadzone || value < -deadzone ? value : 0
 }
 

--- a/src/renderer/utils/gamepad/index.ts
+++ b/src/renderer/utils/gamepad/index.ts
@@ -3,9 +3,20 @@ import { ITwistMsg } from '@/renderer/utils/ros/rosMsgs.types'
 import { Vector3 } from '@/renderer/utils/math/types'
 import { store } from '@/renderer/store/store'
 
+/**
+ * Function to add a deadzone to a gamepad axis
+ * @param value The value of the axis
+ * @returns The value of the axis with the deadzone applied
+ */
 export const deadzone = (value: number): number => {
   const deadzone = 0.1
-  return value > deadzone || value < -deadzone ? value : 0
+
+  if (Math.abs(value) < deadzone) {
+    return 0
+  } else {
+    // Scale the value to be between 0 and 1 if positive, or -1 and 0 if negative
+    return (value - Math.sign(value) * deadzone) / (1 - deadzone)
+  }
 }
 
 export const mapToTwist = (

--- a/src/renderer/utils/gamepad/index.ts
+++ b/src/renderer/utils/gamepad/index.ts
@@ -4,7 +4,7 @@ import { Vector3 } from '@/renderer/utils/math/types'
 import { store } from '@/renderer/store/store'
 
 export const deadzone = (value: number): number => {
-  const deadzone = 0.05
+  const deadzone = 0.15
   return value > deadzone || value < -deadzone ? value : 0
 }
 

--- a/src/renderer/utils/gamepad/index.ts
+++ b/src/renderer/utils/gamepad/index.ts
@@ -4,7 +4,7 @@ import { Vector3 } from '@/renderer/utils/math/types'
 import { store } from '@/renderer/store/store'
 
 /**
- * Function to add a deadzone to a gamepad axis
+ * Function that adds a deadzone to a gamepad axis
  * @param value The value of the axis
  * @returns The value of the axis with the deadzone applied
  */


### PR DESCRIPTION
After some testing, a latency was noticed when doing a long movement with the arm. To improve the performance of the controls the logic was changed a bit to make sure that arm commands are only published when the joystick is being moved. The deadman switch was also removed to improve the feeling of the controls. This change was requested and proven useful after testing Kinova's Gen3 robotic arm, since they use the same controls, but without a deadman switch. 