### PR TITLE
Change joystick axis depending on selected joint

### DIFF
--- a/src/renderer/inputSystem/armModeActions.ts
+++ b/src/renderer/inputSystem/armModeActions.ts
@@ -1,7 +1,4 @@
-import {
-  buttons as buttonMappings,
-  sticks,
-} from '@/renderer/inputSystem/mappings'
+import { buttons as buttonMappings } from '@/renderer/inputSystem/mappings'
 import { rosClient } from '@/renderer/utils/ros/rosClient'
 import { Action } from '@/renderer/inputSystem/@types'
 import { TopicOptions } from '@/renderer/utils/ros/roslib-ts-client/@types'
@@ -72,10 +69,11 @@ export const armModeActions: Action[] = [
 
       const gamepad = ctx.gamepadState.gamepad
       if (armService.state.matches('joint')) {
-        if (deadzone(gamepad.axes[sticks.left.vertical]) !== 0) {
+        const selectedJoint = armService.state.context as ArmContext
+        if (deadzone(gamepad.axes[selectedJoint.axis]) !== 0) {
           rosClient.publish(jointGoalTopic, {
-            joint_index: (armService.state.context as ArmContext).jointValue,
-            joint_velocity: -gamepad.axes[sticks.left.vertical],
+            joint_index: selectedJoint.jointValue,
+            joint_velocity: -gamepad.axes[selectedJoint.axis],
           })
         }
       }

--- a/src/renderer/state/arm.ts
+++ b/src/renderer/state/arm.ts
@@ -1,7 +1,9 @@
 import { Machine, interpret } from 'xstate'
+import { sticks } from '../inputSystem/mappings'
 
 export interface ArmContext {
   jointValue: number
+  axis: number
 }
 
 interface ArmStateSchema {
@@ -17,7 +19,20 @@ type ArmEvent =
   | { type: 'INCREMENT_JOINT' }
   | { type: 'DECREMENT_JOINT' }
 
-const context: ArmContext = { jointValue: 0 }
+const context: ArmContext = {
+  jointValue: 0,
+  axis: sticks.left.horizontal,
+}
+
+// Array that defines which axis each joint is mapped to
+const armJointMappings = [
+  sticks.left.horizontal, // Joint 1 left/right
+  sticks.left.vertical, // Joint 2 up/down
+  sticks.left.vertical, // Joint 3 up/down
+  sticks.left.horizontal, // Joint 4 left/right
+  sticks.left.vertical, // Joint 5 up/down
+  sticks.left.horizontal, // Joint 6 left/right
+]
 
 export const armMachine = Machine<ArmContext, ArmStateSchema, ArmEvent>(
   {
@@ -44,11 +59,13 @@ export const armMachine = Machine<ArmContext, ArmStateSchema, ArmEvent>(
       decrement_joint: () => {
         if (context.jointValue < 6 && context.jointValue > 0) {
           context.jointValue--
+          context.axis = armJointMappings[context.jointValue]
         }
       },
       increment_joint: () => {
         if (context.jointValue < 5 && context.jointValue >= 0) {
           context.jointValue++
+          context.axis = armJointMappings[context.jointValue]
         }
       },
     },


### PR DESCRIPTION
Each can now be controlled using the correct axis. For example, the first joint is controlled using the X axis on the joystick, because it goes from left to right and the second joint is controlled using the Y axis, because it goes up and down.