### PR TITLE
Use hostname instead of ip to connect to jetson

### DIFF
--- a/src/renderer/store/modules/ros.ts
+++ b/src/renderer/store/modules/ros.ts
@@ -13,7 +13,7 @@ export interface RosState {
 
 export const initialState: RosState = {
   namespace: 'capra_ui/',
-  IP: '192.168.1.150',
+  IP: 'jetson',
   port: '9090',
   videoServerPort: '8080',
   descriptionServerPort: '88',


### PR DESCRIPTION
The ip address has changed, all the configuration must be changed.
With a hostname, the ip can change, the connection will still be possible.