### PR TITLE
Robot name flexibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capra_web_ui",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "author": {
     "name": "Club Capra",
     "email": "admin@clubcapra.com",

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,20 +1,20 @@
-import React, { FC, StrictMode, useEffect } from 'react'
-import { HashRouter } from 'react-router-dom'
-import { ThemeProvider, createGlobalStyle } from 'styled-components'
-import { Provider } from 'react-redux'
-import { ToastContainer } from 'react-toastify'
-import 'react-toastify/dist/ReactToastify.css'
-import { defaultTheme } from '@/renderer/globalStyles/themes/defaultTheme'
-import { Layout } from '@/renderer/components/Layout'
-import { store } from '@/renderer/store/store'
-import inputSystem from '@/renderer/inputSystem'
-import { Theme } from '@/renderer/globalStyles/styled'
+import React, { FC, StrictMode, useEffect } from 'react';
+import { HashRouter } from 'react-router-dom';
+import { ThemeProvider, createGlobalStyle } from 'styled-components';
+import { Provider } from 'react-redux';
+import { ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
+import { defaultTheme } from '@/renderer/globalStyles/themes/defaultTheme';
+import { Layout } from '@/renderer/components/Layout';
+import { store } from '@/renderer/store/store';
+import inputSystem from '@/renderer/inputSystem';
+import { Theme } from '@/renderer/globalStyles/styled';
 
 export const App: FC = () => {
   useEffect(() => {
-    inputSystem.start()
-    return () => inputSystem.stop()
-  }, [])
+    inputSystem.start();
+    return () => inputSystem.stop();
+  }, []);
 
   return (
     <StrictMode>
@@ -30,8 +30,8 @@ export const App: FC = () => {
         </HashRouter>
       </Provider>
     </StrictMode>
-  )
-}
+  );
+};
 
 const GlobalStyles = createGlobalStyle<{ theme: Theme }>`
   html { height: 100%; }
@@ -56,4 +56,4 @@ const GlobalStyles = createGlobalStyle<{ theme: Theme }>`
     --toastify-color-warning: ${(props) => props.theme.colors.warning};
     --toastify-color-error: ${(props) => props.theme.colors.danger};
   }
-`
+`;

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,6 +1,6 @@
 import React, { FC, StrictMode, useEffect } from 'react'
 import { HashRouter } from 'react-router-dom'
-import { ThemeProvider } from 'styled-components'
+import { ThemeProvider, createGlobalStyle } from 'styled-components'
 import { Provider } from 'react-redux'
 import { ToastContainer } from 'react-toastify'
 import 'react-toastify/dist/ReactToastify.css'
@@ -8,7 +8,6 @@ import { defaultTheme } from '@/renderer/globalStyles/themes/defaultTheme'
 import { Layout } from '@/renderer/components/Layout'
 import { store } from '@/renderer/store/store'
 import inputSystem from '@/renderer/inputSystem'
-import { createGlobalStyle } from 'styled-components'
 import { Theme } from '@/renderer/globalStyles/styled'
 
 export const App: FC = () => {

--- a/src/renderer/components/EStopButton.tsx
+++ b/src/renderer/components/EStopButton.tsx
@@ -6,11 +6,8 @@ import { useOpenClose } from '@/renderer/hooks/useOpenClose'
 import { styled } from '@/renderer/globalStyles/styled'
 import { darken } from 'polished'
 import { log } from '@/renderer/logger'
-
-// const topic: TopicOptions<boolean> = {
-//   name: 'markhor/estop_status',
-//   messageType: 'std_msgs/Bool',
-// }
+import { selectRobotName } from '../store/modules/ros'
+import { useSelector } from '@/renderer/hooks/typedUseSelector'
 
 interface StopButtonProps {
   onClick: () => void
@@ -19,14 +16,6 @@ interface StopButtonProps {
 const StopButton: FC<StopButtonProps> = ({ onClick }) => {
   const [text] = useState('EMERGENCY STOP')
 
-  // useRosSubscribe(topic, (message) => {
-  //   if (message.data) {
-  //     setText('EMERGENCY STOP')
-  //   } else {
-  //     setText('REARM')
-  //   }
-  // })
-
   return (
     <StyledStopButton onClick={onClick}>
       <span>{text}</span>
@@ -34,13 +23,15 @@ const StopButton: FC<StopButtonProps> = ({ onClick }) => {
   )
 }
 
+//TODO change robotName for 'capra' or an organisation field equivalent. Both UI side and in the estop code.
 export const EStopButton: FC = () => {
   const [isModalOpen, openModal, closeModal] = useOpenClose()
+  const robotName = useSelector(selectRobotName)
 
   const stopRobot = () => {
     log.info('ESTOP: stopping robot')
     rosClient
-      .callService({ name: 'markhor/estop_disable', serviceType: '' }, '')
+      .callService({ name: { robotName } + '/estop_disable', serviceType: '' }, '')
       .catch(log.error)
     openModal()
   }
@@ -48,7 +39,7 @@ export const EStopButton: FC = () => {
   const restartRobot = () => {
     log.info('ESTOP: restarting robot')
     rosClient
-      .callService({ name: 'markhor/estop_enable', serviceType: '' }, '')
+      .callService({ name: { robotName } + '/estop_enable', serviceType: '' }, '')
       .catch(log.error)
     closeModal()
   }

--- a/src/renderer/components/EStopButton.tsx
+++ b/src/renderer/components/EStopButton.tsx
@@ -1,35 +1,35 @@
-import React, { FC, useState } from 'react'
-import { Modal } from './common/Modal'
-import { Button } from './common/Button'
-import { rosClient } from '@/renderer/utils/ros/rosClient'
-import { useOpenClose } from '@/renderer/hooks/useOpenClose'
-import { styled } from '@/renderer/globalStyles/styled'
-import { darken } from 'polished'
-import { log } from '@/renderer/logger'
-import { selectRobotName } from '@/renderer/store/modules/ros'
-import { useSelector } from '@/renderer/hooks/typedUseSelector'
+import React, { FC, useState } from 'react';
+import { Modal } from './common/Modal';
+import { Button } from './common/Button';
+import { rosClient } from '@/renderer/utils/ros/rosClient';
+import { useOpenClose } from '@/renderer/hooks/useOpenClose';
+import { styled } from '@/renderer/globalStyles/styled';
+import { darken } from 'polished';
+import { log } from '@/renderer/logger';
+import { selectRobotName } from '@/renderer/store/modules/ros';
+import { useSelector } from '@/renderer/hooks/typedUseSelector';
 
 interface StopButtonProps {
-  onClick: () => void
+  onClick: () => void;
 }
 
 const StopButton: FC<StopButtonProps> = ({ onClick }) => {
-  const [text] = useState('EMERGENCY STOP')
+  const [text] = useState('EMERGENCY STOP');
 
   return (
     <StyledStopButton onClick={onClick}>
       <span>{text}</span>
     </StyledStopButton>
-  )
-}
+  );
+};
 
 //TODO change robotName for 'capra' or an organisation field equivalent. Both UI side and in the estop code.
 export const EStopButton: FC = () => {
-  const [isModalOpen, openModal, closeModal] = useOpenClose()
-  const robotName = useSelector(selectRobotName)
+  const [isModalOpen, openModal, closeModal] = useOpenClose();
+  const robotName = useSelector(selectRobotName);
 
   const stopRobot = () => {
-    log.info('ESTOP: stopping robot')
+    log.info('ESTOP: stopping robot');
     rosClient
       .callService(
         {
@@ -38,12 +38,12 @@ export const EStopButton: FC = () => {
         },
         ''
       )
-      .catch(log.error)
-    openModal()
-  }
+      .catch(log.error);
+    openModal();
+  };
 
   const restartRobot = () => {
-    log.info('ESTOP: restarting robot')
+    log.info('ESTOP: restarting robot');
     rosClient
       .callService(
         {
@@ -52,9 +52,9 @@ export const EStopButton: FC = () => {
         },
         ''
       )
-      .catch(log.error)
-    closeModal()
-  }
+      .catch(log.error);
+    closeModal();
+  };
 
   return (
     <>
@@ -78,8 +78,8 @@ export const EStopButton: FC = () => {
         <p>Do you want to restart it?</p>
       </Modal>
     </>
-  )
-}
+  );
+};
 
 const StyledStopButton = styled.div`
   height: 100%;
@@ -106,4 +106,4 @@ const StyledStopButton = styled.div`
     writing-mode: vertical-rl;
     text-orientation: upright;
   }
-`
+`;

--- a/src/renderer/components/EStopButton.tsx
+++ b/src/renderer/components/EStopButton.tsx
@@ -6,7 +6,7 @@ import { useOpenClose } from '@/renderer/hooks/useOpenClose'
 import { styled } from '@/renderer/globalStyles/styled'
 import { darken } from 'polished'
 import { log } from '@/renderer/logger'
-import { selectRobotName } from '../store/modules/ros'
+import { selectRobotName } from '@/renderer/store/modules/ros'
 import { useSelector } from '@/renderer/hooks/typedUseSelector'
 
 interface StopButtonProps {
@@ -31,7 +31,13 @@ export const EStopButton: FC = () => {
   const stopRobot = () => {
     log.info('ESTOP: stopping robot')
     rosClient
-      .callService({ name: { robotName } + '/estop_disable', serviceType: '' }, '')
+      .callService(
+        {
+          name: `${robotName}/estop_disable`,
+          serviceType: '',
+        },
+        ''
+      )
       .catch(log.error)
     openModal()
   }
@@ -39,7 +45,13 @@ export const EStopButton: FC = () => {
   const restartRobot = () => {
     log.info('ESTOP: restarting robot')
     rosClient
-      .callService({ name: { robotName } + '/estop_enable', serviceType: '' }, '')
+      .callService(
+        {
+          name: `${robotName}/estop_enable`,
+          serviceType: '',
+        },
+        ''
+      )
       .catch(log.error)
     closeModal()
   }

--- a/src/renderer/components/FlippersView.tsx
+++ b/src/renderer/components/FlippersView.tsx
@@ -9,6 +9,7 @@ import { selectReverse } from '@/renderer/store/modules/input'
 import { useSelector } from '@/renderer/hooks/typedUseSelector'
 import ROSLIB from 'roslib'
 import { rosClient } from '../utils/ros/rosClient'
+import { selectRobotName } from '../store/modules/ros'
 
 interface Props {
   flipper: IFlipperData
@@ -24,24 +25,16 @@ interface PositionsMsg {
   positions: number[]
 }
 
-const flipperUpperLimitParam = new ROSLIB.Param({
-  name: 'markhor/flippers/markhor_flippers_node/front_left_drive_upper_limit',
-  ros: rosClient.ros,
-})
-
-const flipperLowerLimitParam = new ROSLIB.Param({
-  name: 'markhor/flippers/markhor_flippers_node/front_left_drive_lower_limit',
-  ros: rosClient.ros,
-})
-
-const flipperPositionTopic: TopicOptions = {
-  name: '/markhor/flippers/flipper_positions',
-  messageType: '/markhor_flippers/FlipperPositions',
-}
-
 export const FlippersView: FC = () => {
   const isReverse = useSelector(selectReverse)
   const [flipperPositions, setFlipperPositions] = useState<number[]>([])
+  const robotName = useSelector(selectRobotName)
+
+  const flipperPositionTopic: TopicOptions = {
+    name: { robotName } + '/flippers/flipper_positions',
+    messageType: '/' + { robotName } + '_flippers/FlipperPositions',
+  }
+
   useRosSubscribeNoData<PositionsMsg>(
     flipperPositionTopic,
     useCallback((message) => {
@@ -121,6 +114,17 @@ const FlipperArea: FC<Props> = ({ flipper, name, flipperPosition }) => {
   const [motorCurrentValue, setMotorCurrentValue] = useState<string>('0')
   const [flipperUpperLimit, setFlipperUpperLimit] = useState<number>(0)
   const [flipperLowerLimit, setFlipperLowerLimit] = useState<number>(0)
+  const robotName = useSelector(selectRobotName)
+
+  const flipperUpperLimitParam = new ROSLIB.Param({
+    name: { robotName } + '/flippers/' + { robotName } + '_flippers_node/front_left_drive_upper_limit',
+    ros: rosClient.ros,
+  })
+
+  const flipperLowerLimitParam = new ROSLIB.Param({
+    name: { robotName } + '/flippers/' + { robotName } + '_flippers_node/front_left_drive_lower_limit',
+    ros: rosClient.ros,
+  })
 
   useEffect(() => {
     if (!flipperPosition) {

--- a/src/renderer/components/FlippersView.tsx
+++ b/src/renderer/components/FlippersView.tsx
@@ -1,52 +1,52 @@
-import { styled } from '@/renderer/globalStyles/styled'
-import { TopicOptions } from '@/renderer/utils/ros/roslib-ts-client/@types'
+import { styled } from '@/renderer/globalStyles/styled';
+import { TopicOptions } from '@/renderer/utils/ros/roslib-ts-client/@types';
 import {
   useRosSubscribe,
   useRosSubscribeNoData,
-} from '@/renderer/hooks/useRosSubscribe'
-import React, { FC, useCallback, useEffect, useState } from 'react'
+} from '@/renderer/hooks/useRosSubscribe';
+import React, { FC, useCallback, useEffect, useState } from 'react';
 import {
   selectReverse,
   selectRobotNameState,
-} from '@/renderer/store/modules/input'
-import { useSelector } from '@/renderer/hooks/typedUseSelector'
-import ROSLIB from 'roslib'
-import { rosClient } from '../utils/ros/rosClient'
-import { selectRobotName } from '@/renderer/store/modules/ros'
-import { store } from '@/renderer/store/store'
+} from '@/renderer/store/modules/input';
+import { useSelector } from '@/renderer/hooks/typedUseSelector';
+import ROSLIB from 'roslib';
+import { rosClient } from '../utils/ros/rosClient';
+import { selectRobotName } from '@/renderer/store/modules/ros';
+import { store } from '@/renderer/store/store';
 
 interface Props {
-  flipper: IFlipperData
-  name: string
-  flipperPosition: number
+  flipper: IFlipperData;
+  name: string;
+  flipperPosition: number;
 }
 
 interface ViewProps {
-  flipperPositions: number[]
+  flipperPositions: number[];
 }
 
 interface PositionsMsg {
-  positions: number[]
+  positions: number[];
 }
 
 export const FlippersView: FC = () => {
-  const isReverse = useSelector(selectReverse)
-  const [flipperPositions, setFlipperPositions] = useState<number[]>([])
-  const robotName = useSelector(selectRobotName)
+  const isReverse = useSelector(selectReverse);
+  const [flipperPositions, setFlipperPositions] = useState<number[]>([]);
+  const robotName = useSelector(selectRobotName);
 
   const flipperPositionTopic: TopicOptions = {
     name: `${robotName}/flippers/flipper_positions`,
     messageType: `/${robotName}_flippers/FlipperPositions`,
-  }
+  };
 
   useRosSubscribeNoData<PositionsMsg>(
     flipperPositionTopic,
     useCallback((message) => {
       if (message.positions[0] !== flipperPositions[0]) {
-        setFlipperPositions(message.positions)
+        setFlipperPositions(message.positions);
       }
     }, [])
-  )
+  );
   return (
     <StyledFlippersView>
       {isReverse ? (
@@ -55,11 +55,11 @@ export const FlippersView: FC = () => {
         <FlippersForwardView flipperPositions={flipperPositions} />
       )}
     </StyledFlippersView>
-  )
-}
+  );
+};
 
 const FlippersForwardView: FC<ViewProps> = ({ flipperPositions }) => {
-  const flipperInfo: IFlippers = flippers()
+  const flipperInfo: IFlippers = flippers();
   return (
     <>
       <StyledTRArea
@@ -83,11 +83,11 @@ const FlippersForwardView: FC<ViewProps> = ({ flipperPositions }) => {
         flipperPosition={flipperPositions[3]}
       />
     </>
-  )
-}
+  );
+};
 
 const FlippersReverseView: FC<ViewProps> = ({ flipperPositions }) => {
-  const flipperInfo: IFlippers = flippers()
+  const flipperInfo: IFlippers = flippers();
   return (
     <>
       <StyledTRArea
@@ -111,30 +111,30 @@ const FlippersReverseView: FC<ViewProps> = ({ flipperPositions }) => {
         flipperPosition={flipperPositions[3]}
       />
     </>
-  )
-}
+  );
+};
 
 const FlipperArea: FC<Props> = ({ flipper, name, flipperPosition }) => {
-  const [position, setPosition] = useState<string>('0.00')
-  const [motorCurrentColor, setMotorCurrentColor] = useState<string>('')
-  const [motorCurrentValue, setMotorCurrentValue] = useState<string>('0')
-  const [flipperUpperLimit, setFlipperUpperLimit] = useState<number>(0)
-  const [flipperLowerLimit, setFlipperLowerLimit] = useState<number>(0)
-  const robotName = useSelector(selectRobotNameState)
+  const [position, setPosition] = useState<string>('0.00');
+  const [motorCurrentColor, setMotorCurrentColor] = useState<string>('');
+  const [motorCurrentValue, setMotorCurrentValue] = useState<string>('0');
+  const [flipperUpperLimit, setFlipperUpperLimit] = useState<number>(0);
+  const [flipperLowerLimit, setFlipperLowerLimit] = useState<number>(0);
+  const robotName = useSelector(selectRobotNameState);
 
   const flipperUpperLimitParam = new ROSLIB.Param({
     name: `${robotName}/flippers/${robotName}_flippers_node/front_left_drive_upper_limit`,
     ros: rosClient.ros,
-  })
+  });
 
   const flipperLowerLimitParam = new ROSLIB.Param({
     name: `${robotName}/flippers/${robotName}_flippers_node/front_left_drive_lower_limit`,
     ros: rosClient.ros,
-  })
+  });
 
   useEffect(() => {
     if (!flipperPosition) {
-      setPosition('0')
+      setPosition('0');
     } else if (flipperLowerLimit && flipperUpperLimit) {
       setPosition(
         (
@@ -142,14 +142,14 @@ const FlipperArea: FC<Props> = ({ flipper, name, flipperPosition }) => {
             (flipperPosition < 0 ? flipperUpperLimit : flipperLowerLimit)) *
           -100
         ).toFixed(2)
-      )
+      );
     }
     if (!motorCurrentValue) {
-      setMotorCurrentValue('0')
-      setMotorCurrentColor('')
+      setMotorCurrentValue('0');
+      setMotorCurrentColor('');
     }
     if (!motorCurrentColor) {
-      setMotorCurrentColor('')
+      setMotorCurrentColor('');
     }
   }, [
     motorCurrentValue,
@@ -157,37 +157,37 @@ const FlipperArea: FC<Props> = ({ flipper, name, flipperPosition }) => {
     flipperPosition,
     flipperUpperLimit,
     flipperLowerLimit,
-  ])
+  ]);
 
   // Load flipper limits from ROS
   useEffect(() => {
     flipperLowerLimitParam.get((value) => {
       if (value) {
-        setFlipperLowerLimit(value as number)
+        setFlipperLowerLimit(value as number);
       }
-    })
+    });
     flipperUpperLimitParam.get((value) => {
       if (value) {
-        setFlipperUpperLimit(value as number)
+        setFlipperUpperLimit(value as number);
       }
-    })
-  }, [])
+    });
+  }, []);
 
   useRosSubscribe(
     flipper.topicMotorCurrent,
     useCallback((message) => {
-      const motorCurrent = Number(message.data)
-      const maxCurrent = 30
-      const red = '#ff0000'
+      const motorCurrent = Number(message.data);
+      const maxCurrent = 30;
+      const red = '#ff0000';
       const color =
         red +
         Math.floor(
           Math.min(Math.abs(motorCurrent / maxCurrent) * 255, 255)
-        ).toString(16)
-      setMotorCurrentColor(color)
-      setMotorCurrentValue(motorCurrent.toFixed(2))
+        ).toString(16);
+      setMotorCurrentColor(color);
+      setMotorCurrentValue(motorCurrent.toFixed(2));
     }, [])
-  )
+  );
 
   return (
     <StyledFlipperArea>
@@ -196,8 +196,8 @@ const FlipperArea: FC<Props> = ({ flipper, name, flipperPosition }) => {
       <StyledMotorCurrentColor style={{ backgroundColor: motorCurrentColor }} />
       <StyledMotorCurrentValue>{motorCurrentValue} A</StyledMotorCurrentValue>
     </StyledFlipperArea>
-  )
-}
+  );
+};
 
 const StyledFlippersView = styled.div`
   display: grid;
@@ -211,23 +211,23 @@ const StyledFlippersView = styled.div`
   color: ${({ theme }) => theme.colors.fontLight};
   box-shadow: 0 -2px 2px rgba(0, 0, 0, 0.25);
   font-size: 14px;
-`
+`;
 
 const StyledTLArea = styled(FlipperArea)`
   grid-area: tl;
-`
+`;
 
 const StyledTRArea = styled(FlipperArea)`
   grid-area: tl;
-`
+`;
 
 const StyledBLArea = styled(FlipperArea)`
   grid-area: tl;
-`
+`;
 
 const StyledBRArea = styled(FlipperArea)`
   grid-area: tl;
-`
+`;
 
 const StyledFlipperArea = styled.div`
   height: 100%;
@@ -237,40 +237,40 @@ const StyledFlipperArea = styled.div`
     'n p'
     'mcc mcv';
   padding: 2px;
-`
+`;
 const StyledName = styled.p`
   grid-area: n;
   margin-right: 5px;
-`
+`;
 
 const StyledPostion = styled.p`
   grid-area: p;
-`
+`;
 
 const StyledMotorCurrentValue = styled.p`
   grid-area: mcv;
-`
+`;
 
 const StyledMotorCurrentColor = styled.p`
   grid-area: mcc;
   border-radius: 5px;
   margin: 5px;
-`
+`;
 
 export interface IFlippers {
-  id: string
-  flipperFL: IFlipperData
-  flipperFR: IFlipperData
-  flipperRL: IFlipperData
-  flipperRR: IFlipperData
+  id: string;
+  flipperFL: IFlipperData;
+  flipperFR: IFlipperData;
+  flipperRL: IFlipperData;
+  flipperRR: IFlipperData;
 }
 
 export interface IFlipperData {
-  topicMotorCurrent: TopicOptions<string>
+  topicMotorCurrent: TopicOptions<string>;
 }
 
 const flippers = (): IFlippers => {
-  const robotName = selectRobotNameState(store.getState())
+  const robotName = selectRobotNameState(store.getState());
   return {
     id: 'flippers',
     flipperFL: {
@@ -297,5 +297,5 @@ const flippers = (): IFlippers => {
         messageType: 'std_msgs/Float64',
       },
     },
-  }
-}
+  };
+};

--- a/src/renderer/components/FlippersView.tsx
+++ b/src/renderer/components/FlippersView.tsx
@@ -269,9 +269,9 @@ export interface IFlipperData {
   topicMotorCurrent: TopicOptions<string>
 }
 
-const flippers = () => {
+const flippers = (): IFlippers => {
   const robotName = selectRobotNameState(store.getState())
-  const newFlippers: IFlippers = {
+  return {
     id: 'flippers',
     flipperFL: {
       topicMotorCurrent: {
@@ -298,5 +298,4 @@ const flippers = () => {
       },
     },
   }
-  return newFlippers
 }

--- a/src/renderer/components/FlippersView.tsx
+++ b/src/renderer/components/FlippersView.tsx
@@ -9,7 +9,7 @@ import { selectReverse } from '@/renderer/store/modules/input'
 import { useSelector } from '@/renderer/hooks/typedUseSelector'
 import ROSLIB from 'roslib'
 import { rosClient } from '../utils/ros/rosClient'
-import { selectRobotName } from '../store/modules/ros'
+import { selectRobotName } from '@/renderer/store/modules/ros'
 
 interface Props {
   flipper: IFlipperData
@@ -31,8 +31,8 @@ export const FlippersView: FC = () => {
   const robotName = useSelector(selectRobotName)
 
   const flipperPositionTopic: TopicOptions = {
-    name: { robotName } + '/flippers/flipper_positions',
-    messageType: '/' + { robotName } + '_flippers/FlipperPositions',
+    name: `${robotName}/flippers/flipper_positions`,
+    messageType: `/${robotName}_flippers/FlipperPositions`,
   }
 
   useRosSubscribeNoData<PositionsMsg>(
@@ -117,12 +117,12 @@ const FlipperArea: FC<Props> = ({ flipper, name, flipperPosition }) => {
   const robotName = useSelector(selectRobotName)
 
   const flipperUpperLimitParam = new ROSLIB.Param({
-    name: { robotName } + '/flippers/' + { robotName } + '_flippers_node/front_left_drive_upper_limit',
+    name: `${robotName}/flippers/${robotName}_flippers_node/front_left_drive_upper_limit`,
     ros: rosClient.ros,
   })
 
   const flipperLowerLimitParam = new ROSLIB.Param({
-    name: { robotName } + '/flippers/' + { robotName } + '_flippers_node/front_left_drive_lower_limit',
+    name: `${robotName}/flippers/${robotName}_flippers_node/front_left_drive_lower_limit`,
     ros: rosClient.ros,
   })
 

--- a/src/renderer/components/FlippersView.tsx
+++ b/src/renderer/components/FlippersView.tsx
@@ -5,11 +5,15 @@ import {
   useRosSubscribeNoData,
 } from '@/renderer/hooks/useRosSubscribe'
 import React, { FC, useCallback, useEffect, useState } from 'react'
-import { selectReverse } from '@/renderer/store/modules/input'
+import {
+  selectReverse,
+  selectRobotNameState,
+} from '@/renderer/store/modules/input'
 import { useSelector } from '@/renderer/hooks/typedUseSelector'
 import ROSLIB from 'roslib'
 import { rosClient } from '../utils/ros/rosClient'
 import { selectRobotName } from '@/renderer/store/modules/ros'
+import { store } from '@/renderer/store/store'
 
 interface Props {
   flipper: IFlipperData
@@ -55,25 +59,26 @@ export const FlippersView: FC = () => {
 }
 
 const FlippersForwardView: FC<ViewProps> = ({ flipperPositions }) => {
+  const flipperInfo: IFlippers = flippers()
   return (
     <>
       <StyledTRArea
-        flipper={flippers.flipperFL}
+        flipper={flipperInfo.flipperFL}
         name="Front left"
         flipperPosition={flipperPositions[0]}
       />
       <StyledTLArea
-        flipper={flippers.flipperFR}
+        flipper={flipperInfo.flipperFR}
         name="Front right"
         flipperPosition={flipperPositions[1]}
       />
       <StyledBLArea
-        flipper={flippers.flipperRL}
+        flipper={flipperInfo.flipperRL}
         name="Rear left"
         flipperPosition={flipperPositions[2]}
       />
       <StyledBRArea
-        flipper={flippers.flipperRR}
+        flipper={flipperInfo.flipperRR}
         name="Rear right"
         flipperPosition={flipperPositions[3]}
       />
@@ -82,25 +87,26 @@ const FlippersForwardView: FC<ViewProps> = ({ flipperPositions }) => {
 }
 
 const FlippersReverseView: FC<ViewProps> = ({ flipperPositions }) => {
+  const flipperInfo: IFlippers = flippers()
   return (
     <>
       <StyledTRArea
-        flipper={flippers.flipperRL}
+        flipper={flipperInfo.flipperRL}
         name="Front left"
         flipperPosition={flipperPositions[0]}
       />
       <StyledTLArea
-        flipper={flippers.flipperRR}
+        flipper={flipperInfo.flipperRR}
         name="Front right"
         flipperPosition={flipperPositions[1]}
       />
       <StyledBLArea
-        flipper={flippers.flipperFL}
+        flipper={flipperInfo.flipperFL}
         name="Rear left"
         flipperPosition={flipperPositions[2]}
       />
       <StyledBRArea
-        flipper={flippers.flipperFR}
+        flipper={flipperInfo.flipperFR}
         name="Rear right"
         flipperPosition={flipperPositions[3]}
       />
@@ -114,7 +120,7 @@ const FlipperArea: FC<Props> = ({ flipper, name, flipperPosition }) => {
   const [motorCurrentValue, setMotorCurrentValue] = useState<string>('0')
   const [flipperUpperLimit, setFlipperUpperLimit] = useState<number>(0)
   const [flipperLowerLimit, setFlipperLowerLimit] = useState<number>(0)
-  const robotName = useSelector(selectRobotName)
+  const robotName = useSelector(selectRobotNameState)
 
   const flipperUpperLimitParam = new ROSLIB.Param({
     name: `${robotName}/flippers/${robotName}_flippers_node/front_left_drive_upper_limit`,
@@ -263,30 +269,34 @@ export interface IFlipperData {
   topicMotorCurrent: TopicOptions<string>
 }
 
-const flippers: IFlippers = {
-  id: 'flippers',
-  flipperFL: {
-    topicMotorCurrent: {
-      name: '/markhor/flippers/flipper_fl_motor_current',
-      messageType: 'std_msgs/Float64',
+const flippers = () => {
+  const robotName = selectRobotNameState(store.getState())
+  const newFlippers: IFlippers = {
+    id: 'flippers',
+    flipperFL: {
+      topicMotorCurrent: {
+        name: `${robotName}/flippers/flipper_fl_motor_current`,
+        messageType: 'std_msgs/Float64',
+      },
     },
-  },
-  flipperFR: {
-    topicMotorCurrent: {
-      name: '/markhor/flippers/flipper_fr_motor_current',
-      messageType: 'std_msgs/Float64',
+    flipperFR: {
+      topicMotorCurrent: {
+        name: `${robotName}/flippers/flipper_fr_motor_current`,
+        messageType: 'std_msgs/Float64',
+      },
     },
-  },
-  flipperRL: {
-    topicMotorCurrent: {
-      name: '/markhor/flippers/flipper_rl_motor_current',
-      messageType: 'std_msgs/Float64',
+    flipperRL: {
+      topicMotorCurrent: {
+        name: `${robotName}/flippers/flipper_rl_motor_current`,
+        messageType: 'std_msgs/Float64',
+      },
     },
-  },
-  flipperRR: {
-    topicMotorCurrent: {
-      name: '/markhor/flippers/flipper_rr_motor_current',
-      messageType: 'std_msgs/Float64',
+    flipperRR: {
+      topicMotorCurrent: {
+        name: `${robotName}/flippers/flipper_rr_motor_current`,
+        messageType: 'std_msgs/Float64',
+      },
     },
-  },
+  }
+  return newFlippers
 }

--- a/src/renderer/components/pages/Config/pages/GeneralConfig.tsx
+++ b/src/renderer/components/pages/Config/pages/GeneralConfig.tsx
@@ -1,15 +1,15 @@
-import React, { FC, ChangeEvent } from 'react'
-import { LabeledInput } from '@/renderer/components/common/LabeledInput'
-import { Button } from '@/renderer/components/common/Button'
-import { SectionTitle } from '@/renderer/components/pages/Config/styles'
-import { useActor } from '@xstate/react'
-import { rosService } from '@/renderer/state/ros'
-import { clearStoreCache } from '@/renderer/store/localStorage'
-import { useDispatch } from 'react-redux'
+import React, { FC, ChangeEvent } from 'react';
+import { LabeledInput } from '@/renderer/components/common/LabeledInput';
+import { Button } from '@/renderer/components/common/Button';
+import { SectionTitle } from '@/renderer/components/pages/Config/styles';
+import { useActor } from '@xstate/react';
+import { rosService } from '@/renderer/state/ros';
+import { clearStoreCache } from '@/renderer/store/localStorage';
+import { useDispatch } from 'react-redux';
 import {
   debugTabSlice,
   selectDebugTabVisible,
-} from '@/renderer/store/modules/debugTab'
+} from '@/renderer/store/modules/debugTab';
 import {
   rosSlice,
   selectBaseLinkName,
@@ -18,30 +18,30 @@ import {
   selectNamespace,
   selectPort,
   selectRobotName,
-} from '@/renderer/store/modules/ros'
-import { useSelector } from '@/renderer/hooks/typedUseSelector'
+} from '@/renderer/store/modules/ros';
+import { useSelector } from '@/renderer/hooks/typedUseSelector';
 
 const ConnectionSection = () => {
-  const IP = useSelector(selectIP)
-  const port = useSelector(selectPort)
-  const robotName = useSelector(selectRobotName)
-  const dispatch = useDispatch()
-  const [state, send] = useActor(rosService)
+  const IP = useSelector(selectIP);
+  const port = useSelector(selectPort);
+  const robotName = useSelector(selectRobotName);
+  const dispatch = useDispatch();
+  const [state, send] = useActor(rosService);
 
   const updateIp = (e: ChangeEvent<HTMLInputElement>) => {
-    dispatch(rosSlice.actions.updateIP(e.target.value))
-  }
+    dispatch(rosSlice.actions.updateIP(e.target.value));
+  };
 
   const updatePort = (e: ChangeEvent<HTMLInputElement>) => {
-    dispatch(rosSlice.actions.updatePort(e.target.value))
-  }
+    dispatch(rosSlice.actions.updatePort(e.target.value));
+  };
 
   const updateRobotName = (e: ChangeEvent<HTMLInputElement>) => {
-    dispatch(rosSlice.actions.updateRobotName(e.target.value))
-  }
+    dispatch(rosSlice.actions.updateRobotName(e.target.value));
+  };
 
-  const connect = () => send('CONNECT')
-  const disconnect = () => send('DISCONNECT')
+  const connect = () => send('CONNECT');
+  const disconnect = () => send('DISCONNECT');
 
   return (
     <>
@@ -81,15 +81,15 @@ const ConnectionSection = () => {
         </Button>
       </div>
     </>
-  )
-}
+  );
+};
 
 const NamespaceSection = () => {
-  const namespace = useSelector(selectNamespace)
-  const dispatch = useDispatch()
+  const namespace = useSelector(selectNamespace);
+  const dispatch = useDispatch();
 
   const updateNamespace = (e: ChangeEvent<HTMLInputElement>) =>
-    dispatch(rosSlice.actions.updateNamespace(e.target.value))
+    dispatch(rosSlice.actions.updateNamespace(e.target.value));
 
   return (
     <>
@@ -104,21 +104,21 @@ const NamespaceSection = () => {
         onChange={updateNamespace}
       />
     </>
-  )
-}
+  );
+};
 
 const UrdfDescriptionSection = () => {
-  const dispatch = useDispatch()
-  const descriptionServerPort = useSelector(selectDescriptionServerPort)
-  const baseLinkName = useSelector(selectBaseLinkName)
+  const dispatch = useDispatch();
+  const descriptionServerPort = useSelector(selectDescriptionServerPort);
+  const baseLinkName = useSelector(selectBaseLinkName);
 
   const updateDescriptionPort = (e: ChangeEvent<HTMLInputElement>): void => {
-    dispatch(rosSlice.actions.updateDescriptionServerPort(e.target.value))
-  }
+    dispatch(rosSlice.actions.updateDescriptionServerPort(e.target.value));
+  };
 
   const updateBaseLinkName = (e: ChangeEvent<HTMLInputElement>): void => {
-    dispatch(rosSlice.actions.updateBaseLinkName(e.target.value))
-  }
+    dispatch(rosSlice.actions.updateBaseLinkName(e.target.value));
+  };
 
   return (
     <>
@@ -136,25 +136,25 @@ const UrdfDescriptionSection = () => {
         onChange={updateBaseLinkName}
       />
     </>
-  )
-}
+  );
+};
 
 const DetectedGamepad = () => {
-  const gamepads = [...navigator.getGamepads()]
+  const gamepads = [...navigator.getGamepads()];
   return (
     <>
       <SectionTitle>Gamepads Detected</SectionTitle>
       <ul>{gamepads.map((g) => g && <li key={g?.id}>{g?.id}</li>)}</ul>
     </>
-  )
-}
+  );
+};
 
 const ToggleDebug = () => {
-  const visible = useSelector(selectDebugTabVisible)
-  const dispatch = useDispatch()
+  const visible = useSelector(selectDebugTabVisible);
+  const dispatch = useDispatch();
   const toggleDebugTab = (): void => {
-    dispatch(debugTabSlice.actions.toggleVisible())
-  }
+    dispatch(debugTabSlice.actions.toggleVisible());
+  };
 
   return (
     <>
@@ -162,8 +162,8 @@ const ToggleDebug = () => {
       <p>Debug</p>
       <input type="checkbox" onChange={toggleDebugTab} checked={visible} />
     </>
-  )
-}
+  );
+};
 
 export const GeneralConfig: FC = () => (
   <>
@@ -174,4 +174,4 @@ export const GeneralConfig: FC = () => (
     <DetectedGamepad />
     <ToggleDebug />
   </>
-)
+);

--- a/src/renderer/components/pages/Config/pages/GeneralConfig.tsx
+++ b/src/renderer/components/pages/Config/pages/GeneralConfig.tsx
@@ -47,10 +47,7 @@ const ConnectionSection = () => {
     <>
       <SectionTitle>Connection</SectionTitle>
       <div style={{ display: 'flex' }}>
-        <LabeledInput
-          label="IP address"
-          value={IP}
-          onChange={updateIp} />
+        <LabeledInput label="IP address" value={IP} onChange={updateIp} />
         <LabeledInput
           label="rosbrige_server port"
           value={port}
@@ -59,7 +56,8 @@ const ConnectionSection = () => {
         <LabeledInput
           label="Robot name"
           value={robotName}
-          onChange={updateRobotName} />
+          onChange={updateRobotName}
+        />
       </div>
 
       <div style={{ display: 'flex' }}>

--- a/src/renderer/components/pages/Config/pages/GeneralConfig.tsx
+++ b/src/renderer/components/pages/Config/pages/GeneralConfig.tsx
@@ -17,12 +17,14 @@ import {
   selectIP,
   selectNamespace,
   selectPort,
+  selectRobotName,
 } from '@/renderer/store/modules/ros'
 import { useSelector } from '@/renderer/hooks/typedUseSelector'
 
 const ConnectionSection = () => {
   const IP = useSelector(selectIP)
   const port = useSelector(selectPort)
+  const robotName = useSelector(selectRobotName)
   const dispatch = useDispatch()
   const [state, send] = useActor(rosService)
 
@@ -34,6 +36,10 @@ const ConnectionSection = () => {
     dispatch(rosSlice.actions.updatePort(e.target.value))
   }
 
+  const updateRobotName = (e: ChangeEvent<HTMLInputElement>) => {
+    dispatch(rosSlice.actions.updateRobotName(e.target.value))
+  }
+
   const connect = () => send('CONNECT')
   const disconnect = () => send('DISCONNECT')
 
@@ -41,12 +47,19 @@ const ConnectionSection = () => {
     <>
       <SectionTitle>Connection</SectionTitle>
       <div style={{ display: 'flex' }}>
-        <LabeledInput label="IP address" value={IP} onChange={updateIp} />
+        <LabeledInput
+          label="IP address"
+          value={IP}
+          onChange={updateIp} />
         <LabeledInput
           label="rosbrige_server port"
           value={port}
           onChange={updatePort}
         />
+        <LabeledInput
+          label="Robot name"
+          value={robotName}
+          onChange={updateRobotName} />
       </div>
 
       <div style={{ display: 'flex' }}>

--- a/src/renderer/inputSystem/flipperModeActions.ts
+++ b/src/renderer/inputSystem/flipperModeActions.ts
@@ -5,7 +5,6 @@ import { TopicOptions } from '@/renderer/utils/ros/roslib-ts-client/@types'
 import { IJoyMsg } from '@/renderer/utils/ros/rosMsgs.types'
 import { store } from '@/renderer/store/store'
 import { flipperService } from '@/renderer/state/flipper'
-import { log } from '@/renderer/logger'
 import { inputSlice, selectReverse } from '@/renderer/store/modules/input'
 import { handleTpvControl } from './tpvControl'
 

--- a/src/renderer/inputSystem/flipperModeActions.ts
+++ b/src/renderer/inputSystem/flipperModeActions.ts
@@ -1,31 +1,31 @@
-import { buttons as buttonMappings } from '@/renderer/inputSystem/mappings'
-import { rosClient } from '@/renderer/utils/ros/rosClient'
-import { Action } from '@/renderer/inputSystem/@types'
-import { TopicOptions } from '@/renderer/utils/ros/roslib-ts-client/@types'
-import { IJoyMsg } from '@/renderer/utils/ros/rosMsgs.types'
-import { store } from '@/renderer/store/store'
-import { flipperService } from '@/renderer/state/flipper'
-import { inputSlice, selectReverse } from '@/renderer/store/modules/input'
-import { handleTpvControl } from './tpvControl'
+import { buttons as buttonMappings } from '@/renderer/inputSystem/mappings';
+import { rosClient } from '@/renderer/utils/ros/rosClient';
+import { Action } from '@/renderer/inputSystem/@types';
+import { TopicOptions } from '@/renderer/utils/ros/roslib-ts-client/@types';
+import { IJoyMsg } from '@/renderer/utils/ros/rosMsgs.types';
+import { store } from '@/renderer/store/store';
+import { flipperService } from '@/renderer/state/flipper';
+import { inputSlice, selectReverse } from '@/renderer/store/modules/input';
+import { handleTpvControl } from './tpvControl';
 
 const joyTopic: TopicOptions = {
   name: '/joy',
   messageType: 'sensor_msgs/Joy',
-}
+};
 
-let joySeqId = 0
+let joySeqId = 0;
 
 const mapGamepadToJoy = (gamepad: Gamepad): IJoyMsg => {
-  const d = new Date()
-  const seconds = Math.round(d.getTime() / 1000)
+  const d = new Date();
+  const seconds = Math.round(d.getTime() / 1000);
 
-  const lt = getBtnValue(gamepad.buttons[buttonMappings.LT])
-  const rt = getBtnValue(gamepad.buttons[buttonMappings.RT])
+  const lt = getBtnValue(gamepad.buttons[buttonMappings.LT]);
+  const rt = getBtnValue(gamepad.buttons[buttonMappings.RT]);
 
-  let axes = gamepad.axes
-  const isReverse = selectReverse(store.getState())
+  let axes = gamepad.axes;
+  const isReverse = selectReverse(store.getState());
   //Disable flipper movement when TPV is active
-  const rightStickEnabled = !gamepad.buttons[buttonMappings.LB].pressed
+  const rightStickEnabled = !gamepad.buttons[buttonMappings.LB].pressed;
   axes = [
     -axes[0],
     isReverse ? axes[1] : -axes[1],
@@ -33,10 +33,10 @@ const mapGamepadToJoy = (gamepad: Gamepad): IJoyMsg => {
     rightStickEnabled ? -axes[2] : 0,
     rightStickEnabled ? -axes[3] : 0,
     rt,
-  ]
-  const deadzone = 0.15
-  axes = axes.map((x) => (x < deadzone && x > -deadzone ? 0.0 : x))
-  const buttons = gamepad.buttons.map((x) => Math.floor(x.value))
+  ];
+  const deadzone = 0.15;
+  axes = axes.map((x) => (x < deadzone && x > -deadzone ? 0.0 : x));
+  const buttons = gamepad.buttons.map((x) => Math.floor(x.value));
   return {
     header: {
       seq: joySeqId++,
@@ -48,11 +48,11 @@ const mapGamepadToJoy = (gamepad: Gamepad): IJoyMsg => {
     },
     axes,
     buttons,
-  }
-}
+  };
+};
 
 const getBtnValue = (rawBtn: GamepadButton) =>
-  typeof rawBtn == 'number' ? rawBtn : rawBtn.value
+  typeof rawBtn == 'number' ? rawBtn : rawBtn.value;
 
 export const flipperModeActions: Action[] = [
   {
@@ -62,10 +62,10 @@ export const flipperModeActions: Action[] = [
       // { type: 'keyboard', code: 'KeyI' },
     ],
     perform: () => {
-      const isReverse = selectReverse(store.getState())
+      const isReverse = selectReverse(store.getState());
       isReverse
         ? flipperService.send('MODE_REAR')
-        : flipperService.send('MODE_FRONT')
+        : flipperService.send('MODE_FRONT');
     },
   },
   {
@@ -75,30 +75,30 @@ export const flipperModeActions: Action[] = [
       // { type: 'keyboard', code: 'KeyK' },
     ],
     perform: () => {
-      const isReverse = selectReverse(store.getState())
+      const isReverse = selectReverse(store.getState());
       isReverse
         ? flipperService.send('MODE_FRONT')
-        : flipperService.send('MODE_REAR')
+        : flipperService.send('MODE_REAR');
     },
   },
   {
     name: 'modeRight',
     bindings: [{ type: 'gamepadBtnDown', button: buttonMappings.dpad.right }],
     perform: () => {
-      const isReverse = selectReverse(store.getState())
+      const isReverse = selectReverse(store.getState());
       isReverse
         ? flipperService.send('MODE_LEFT')
-        : flipperService.send('MODE_RIGHT')
+        : flipperService.send('MODE_RIGHT');
     },
   },
   {
     name: 'modeLeft',
     bindings: [{ type: 'gamepadBtnDown', button: buttonMappings.dpad.left }],
     perform: () => {
-      const isReverse = selectReverse(store.getState())
+      const isReverse = selectReverse(store.getState());
       isReverse
         ? flipperService.send('MODE_RIGHT')
-        : flipperService.send('MODE_LEFT')
+        : flipperService.send('MODE_LEFT');
     },
   },
   {
@@ -112,7 +112,7 @@ export const flipperModeActions: Action[] = [
       Disabled for now since the TPV is used as main camera in forward and reverse modes
       store.dispatch(feedSlice.actions.switchDirection())
       */
-      store.dispatch(inputSlice.actions.toggleReverse())
+      store.dispatch(inputSlice.actions.toggleReverse());
     },
   },
 
@@ -121,14 +121,14 @@ export const flipperModeActions: Action[] = [
     bindings: [{ type: 'gamepad' }],
     perform: (ctx) => {
       if (ctx.type !== 'gamepad') {
-        return
+        return;
       }
 
-      const gamepad = ctx.gamepadState.gamepad
-      const joy = mapGamepadToJoy(ctx.gamepadState.gamepad)
-      rosClient.publish(joyTopic, joy)
+      const gamepad = ctx.gamepadState.gamepad;
+      const joy = mapGamepadToJoy(ctx.gamepadState.gamepad);
+      rosClient.publish(joyTopic, joy);
 
-      handleTpvControl(gamepad)
+      handleTpvControl(gamepad);
     },
   },
-]
+];

--- a/src/renderer/inputSystem/index.ts
+++ b/src/renderer/inputSystem/index.ts
@@ -7,6 +7,8 @@ import { log } from '@/renderer/logger'
 import { armModeActions } from './armModeActions'
 import { flipperModeActions } from './flipperModeActions'
 import { TopicOptions } from '../utils/ros/roslib-ts-client/@types'
+import { selectRobotName } from '../store/modules/ros'
+import { useSelector } from '@/renderer/hooks/typedUseSelector'
 
 const gripperTopic: TopicOptions = {
   name: 'ovis/gripper/position_goal',
@@ -26,7 +28,8 @@ const defaultActions: Action[] = [
       if (controlService.state.matches('nothing') && ctx.type === 'keyboard') {
         return
       }
-      rosClient.callService({ name: 'markhor/estop_disable' }).catch(log.error)
+      const robotName = useSelector(selectRobotName)
+      rosClient.callService({ name: { robotName } + '/estop_disable' }).catch(log.error)
     },
   },
   {

--- a/src/renderer/inputSystem/index.ts
+++ b/src/renderer/inputSystem/index.ts
@@ -1,19 +1,19 @@
-import { InputSystem } from '@/renderer/inputSystem/InputSystem'
-import { buttons as buttonMappings } from '@/renderer/inputSystem/mappings'
-import { rosClient } from '@/renderer/utils/ros/rosClient'
-import { Action } from '@/renderer/inputSystem/@types'
-import { controlService } from '@/renderer/state/control'
-import { log } from '@/renderer/logger'
-import { armModeActions } from './armModeActions'
-import { flipperModeActions } from './flipperModeActions'
-import { TopicOptions } from '../utils/ros/roslib-ts-client/@types'
-import { store } from '@/renderer/store/store'
-import { selectRobotNameState } from '@/renderer/store/modules/input'
+import { InputSystem } from '@/renderer/inputSystem/InputSystem';
+import { buttons as buttonMappings } from '@/renderer/inputSystem/mappings';
+import { rosClient } from '@/renderer/utils/ros/rosClient';
+import { Action } from '@/renderer/inputSystem/@types';
+import { controlService } from '@/renderer/state/control';
+import { log } from '@/renderer/logger';
+import { armModeActions } from './armModeActions';
+import { flipperModeActions } from './flipperModeActions';
+import { TopicOptions } from '../utils/ros/roslib-ts-client/@types';
+import { store } from '@/renderer/store/store';
+import { selectRobotNameState } from '@/renderer/store/modules/input';
 
 const gripperTopic: TopicOptions = {
   name: 'ovis/gripper/position_goal',
   messageType: 'ovis_robotiq_gripper/OvisGripperPosition',
-}
+};
 
 const defaultActions: Action[] = [
   {
@@ -26,23 +26,23 @@ const defaultActions: Action[] = [
       // TODO use redux to toggle the estop and the related UI elements
       // This only disables the drives, if you want to restart it you need to use the UI
       if (controlService.state.matches('nothing') && ctx.type === 'keyboard') {
-        return
+        return;
       }
-      const robotName = selectRobotNameState(store.getState())
+      const robotName = selectRobotNameState(store.getState());
       rosClient
         .callService({ name: `${robotName}/estop_disable` })
-        .catch(log.error)
+        .catch(log.error);
     },
   },
   {
     name: 'toggleArmControl',
     bindings: [{ type: 'gamepadBtnDown', button: buttonMappings.start }],
     perform: () => {
-      controlService.send('TOGGLE')
+      controlService.send('TOGGLE');
       if (controlService.state.matches('arm')) {
-        inputSystem.setActionMap(defaultActions.concat(armModeActions))
+        inputSystem.setActionMap(defaultActions.concat(armModeActions));
       } else {
-        inputSystem.setActionMap(defaultActions.concat(flipperModeActions))
+        inputSystem.setActionMap(defaultActions.concat(flipperModeActions));
       }
     },
   },
@@ -54,7 +54,7 @@ const defaultActions: Action[] = [
       // Toggle gripper
       rosClient.publish(gripperTopic, {
         position: 2,
-      })
+      });
     },
   },
 
@@ -64,11 +64,11 @@ const defaultActions: Action[] = [
     perform: () => {
       rosClient
         .callService({ name: '/capra/wrist_light_toggle' })
-        .catch(log.error)
+        .catch(log.error);
     },
   },
-]
+];
 
-const inputSystem = new InputSystem(defaultActions.concat(flipperModeActions))
+const inputSystem = new InputSystem(defaultActions.concat(flipperModeActions));
 
-export default inputSystem
+export default inputSystem;

--- a/src/renderer/inputSystem/index.ts
+++ b/src/renderer/inputSystem/index.ts
@@ -8,7 +8,7 @@ import { armModeActions } from './armModeActions'
 import { flipperModeActions } from './flipperModeActions'
 import { TopicOptions } from '../utils/ros/roslib-ts-client/@types'
 import { store } from '@/renderer/store/store'
-import { selectRobotName } from '@/renderer/store/modules/input'
+import { selectRobotNameState } from '@/renderer/store/modules/input'
 
 const gripperTopic: TopicOptions = {
   name: 'ovis/gripper/position_goal',
@@ -28,7 +28,7 @@ const defaultActions: Action[] = [
       if (controlService.state.matches('nothing') && ctx.type === 'keyboard') {
         return
       }
-      const robotName = selectRobotName(store.getState())
+      const robotName = selectRobotNameState(store.getState())
       rosClient
         .callService({ name: `${robotName}/estop_disable` })
         .catch(log.error)

--- a/src/renderer/inputSystem/index.ts
+++ b/src/renderer/inputSystem/index.ts
@@ -7,8 +7,8 @@ import { log } from '@/renderer/logger'
 import { armModeActions } from './armModeActions'
 import { flipperModeActions } from './flipperModeActions'
 import { TopicOptions } from '../utils/ros/roslib-ts-client/@types'
-import { selectRobotName } from '../store/modules/ros'
-import { useSelector } from '@/renderer/hooks/typedUseSelector'
+import { store } from '@/renderer/store/store'
+import { selectRobotName } from '@/renderer/store/modules/input'
 
 const gripperTopic: TopicOptions = {
   name: 'ovis/gripper/position_goal',
@@ -28,8 +28,10 @@ const defaultActions: Action[] = [
       if (controlService.state.matches('nothing') && ctx.type === 'keyboard') {
         return
       }
-      const robotName = useSelector(selectRobotName)
-      rosClient.callService({ name: { robotName } + '/estop_disable' }).catch(log.error)
+      const robotName = selectRobotName(store.getState())
+      rosClient
+        .callService({ name: `${robotName}/estop_disable` })
+        .catch(log.error)
     },
   },
   {

--- a/src/renderer/state/flipper.ts
+++ b/src/renderer/state/flipper.ts
@@ -1,9 +1,11 @@
 import { log } from '@/renderer/logger'
 import { rosClient } from '@/renderer/utils/ros/rosClient'
 import { Machine, interpret } from 'xstate'
+import { selectRobotName } from '../store/modules/ros'
+import { useSelector } from '@/renderer/hooks/typedUseSelector'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-interface FlipperContext {}
+interface FlipperContext { }
 
 interface FlipperStateSchema {
   states: {
@@ -120,9 +122,10 @@ type FlipperMode =
   | 'rl_disable'
 
 async function sendFlipperMode(mode: FlipperMode) {
+  const robotName = useSelector(selectRobotName)
   try {
     await rosClient.callService({
-      name: `/markhor/flippers/flipper_mode_${mode}`,
+      name: { robotName } + `/flippers/flipper_mode_${mode}`,
     })
   } catch (e) {
     log.error(e)

--- a/src/renderer/state/flipper.ts
+++ b/src/renderer/state/flipper.ts
@@ -1,11 +1,11 @@
 import { log } from '@/renderer/logger'
 import { rosClient } from '@/renderer/utils/ros/rosClient'
 import { Machine, interpret } from 'xstate'
-import { selectRobotName } from '../store/modules/ros'
-import { useSelector } from '@/renderer/hooks/typedUseSelector'
+import { store } from '@/renderer/store/store'
+import { selectRobotName } from '@/renderer/store/modules/input'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-interface FlipperContext { }
+interface FlipperContext {}
 
 interface FlipperStateSchema {
   states: {
@@ -122,10 +122,10 @@ type FlipperMode =
   | 'rl_disable'
 
 async function sendFlipperMode(mode: FlipperMode) {
-  const robotName = useSelector(selectRobotName)
+  const robotName = selectRobotName(store.getState())
   try {
     await rosClient.callService({
-      name: { robotName } + `/flippers/flipper_mode_${mode}`,
+      name: `${robotName}/flippers/flipper_mode_${mode}`,
     })
   } catch (e) {
     log.error(e)

--- a/src/renderer/state/flipper.ts
+++ b/src/renderer/state/flipper.ts
@@ -2,7 +2,7 @@ import { log } from '@/renderer/logger'
 import { rosClient } from '@/renderer/utils/ros/rosClient'
 import { Machine, interpret } from 'xstate'
 import { store } from '@/renderer/store/store'
-import { selectRobotName } from '@/renderer/store/modules/input'
+import { selectRobotNameState } from '@/renderer/store/modules/input'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface FlipperContext {}
@@ -122,7 +122,7 @@ type FlipperMode =
   | 'rl_disable'
 
 async function sendFlipperMode(mode: FlipperMode) {
-  const robotName = selectRobotName(store.getState())
+  const robotName = selectRobotNameState(store.getState())
   try {
     await rosClient.callService({
       name: `${robotName}/flippers/flipper_mode_${mode}`,

--- a/src/renderer/state/flipper.ts
+++ b/src/renderer/state/flipper.ts
@@ -1,29 +1,29 @@
-import { log } from '@/renderer/logger'
-import { rosClient } from '@/renderer/utils/ros/rosClient'
-import { Machine, interpret } from 'xstate'
-import { store } from '@/renderer/store/store'
-import { selectRobotNameState } from '@/renderer/store/modules/input'
+import { log } from '@/renderer/logger';
+import { rosClient } from '@/renderer/utils/ros/rosClient';
+import { Machine, interpret } from 'xstate';
+import { store } from '@/renderer/store/store';
+import { selectRobotNameState } from '@/renderer/store/modules/input';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface FlipperContext {}
 
 interface FlipperStateSchema {
   states: {
-    front: Record<string, unknown>
-    fl: Record<string, unknown>
-    fr: Record<string, unknown>
-    rear: Record<string, unknown>
-    rl: Record<string, unknown>
-    rr: Record<string, unknown>
-    all: Record<string, unknown>
-  }
+    front: Record<string, unknown>;
+    fl: Record<string, unknown>;
+    fr: Record<string, unknown>;
+    rear: Record<string, unknown>;
+    rl: Record<string, unknown>;
+    rr: Record<string, unknown>;
+    all: Record<string, unknown>;
+  };
 }
 
 type FlipperEvent =
   | { type: 'MODE_FRONT' }
   | { type: 'MODE_REAR' }
   | { type: 'MODE_LEFT' }
-  | { type: 'MODE_RIGHT' }
+  | { type: 'MODE_RIGHT' };
 
 export const flipperMachine = Machine<
   FlipperContext,
@@ -84,32 +84,32 @@ export const flipperMachine = Machine<
   {
     actions: {
       set_mode_all: () => {
-        void sendFlipperMode('front_enable')
-        void sendFlipperMode('rear_enable')
+        void sendFlipperMode('front_enable');
+        void sendFlipperMode('rear_enable');
       },
       set_mode_front: () => {
-        void sendFlipperMode('front_enable')
-        void sendFlipperMode('rear_disable')
+        void sendFlipperMode('front_enable');
+        void sendFlipperMode('rear_disable');
       },
       set_mode_fl: () => {
-        void sendFlipperMode('fr_disable')
+        void sendFlipperMode('fr_disable');
       },
       set_mode_fr: () => {
-        void sendFlipperMode('fl_disable')
+        void sendFlipperMode('fl_disable');
       },
       set_mode_rear: () => {
-        void sendFlipperMode('rear_enable')
-        void sendFlipperMode('front_disable')
+        void sendFlipperMode('rear_enable');
+        void sendFlipperMode('front_disable');
       },
       set_mode_rl: () => {
-        void sendFlipperMode('rr_disable')
+        void sendFlipperMode('rr_disable');
       },
       set_mode_rr: () => {
-        void sendFlipperMode('rl_disable')
+        void sendFlipperMode('rl_disable');
       },
     },
   }
-)
+);
 
 type FlipperMode =
   | 'front_enable'
@@ -119,17 +119,17 @@ type FlipperMode =
   | 'fr_disable'
   | 'fl_disable'
   | 'rr_disable'
-  | 'rl_disable'
+  | 'rl_disable';
 
 async function sendFlipperMode(mode: FlipperMode) {
-  const robotName = selectRobotNameState(store.getState())
+  const robotName = selectRobotNameState(store.getState());
   try {
     await rosClient.callService({
       name: `${robotName}/flippers/flipper_mode_${mode}`,
-    })
+    });
   } catch (e) {
-    log.error(e)
+    log.error(e);
   }
 }
 
-export const flipperService = interpret(flipperMachine).start()
+export const flipperService = interpret(flipperMachine).start();

--- a/src/renderer/store/modules/input.ts
+++ b/src/renderer/store/modules/input.ts
@@ -1,27 +1,27 @@
-import { GlobalState } from '@/renderer/store/store'
-import { createSlice } from '@reduxjs/toolkit'
+import { GlobalState } from '@/renderer/store/store';
+import { createSlice } from '@reduxjs/toolkit';
 
 export interface InputState {
-  reverse: boolean
+  reverse: boolean;
 }
 
 export const initialState: InputState = {
   reverse: false,
-}
+};
 
 export const inputSlice = createSlice({
   name: 'input',
   initialState,
   reducers: {
     toggleReverse: (state) => {
-      state.reverse = !state.reverse
+      state.reverse = !state.reverse;
     },
   },
-})
+});
 
 export const selectReverse = (state: GlobalState): boolean =>
-  state.input.reverse
+  state.input.reverse;
 
 export const selectRobotNameState = (state: GlobalState): string => {
-  return state.ros.robotName
-}
+  return state.ros.robotName;
+};

--- a/src/renderer/store/modules/input.ts
+++ b/src/renderer/store/modules/input.ts
@@ -21,3 +21,7 @@ export const inputSlice = createSlice({
 
 export const selectReverse = (state: GlobalState): boolean =>
   state.input.reverse
+
+export const selectRobotName = (state: GlobalState): string => {
+  return state.ros.robotName
+}

--- a/src/renderer/store/modules/input.ts
+++ b/src/renderer/store/modules/input.ts
@@ -22,6 +22,6 @@ export const inputSlice = createSlice({
 export const selectReverse = (state: GlobalState): boolean =>
   state.input.reverse
 
-export const selectRobotName = (state: GlobalState): string => {
+export const selectRobotNameState = (state: GlobalState): string => {
   return state.ros.robotName
 }

--- a/src/renderer/store/modules/ros.ts
+++ b/src/renderer/store/modules/ros.ts
@@ -1,15 +1,15 @@
-import { CameraType, ICameraData } from '@/renderer/store/modules/feed'
-import { GlobalState } from '@/renderer/store/store'
-import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { CameraType, ICameraData } from '@/renderer/store/modules/feed';
+import { GlobalState } from '@/renderer/store/store';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 export interface RosState {
-  namespace: string
-  IP: string
-  port: string
-  robotName: string
-  videoServerPort: string
-  descriptionServerPort: string
-  baseLinkName: string
+  namespace: string;
+  IP: string;
+  port: string;
+  robotName: string;
+  videoServerPort: string;
+  descriptionServerPort: string;
+  baseLinkName: string;
 }
 
 export const initialState: RosState = {
@@ -20,63 +20,63 @@ export const initialState: RosState = {
   videoServerPort: '8080',
   descriptionServerPort: '88',
   baseLinkName: 'markhor_link_base',
-}
+};
 
 export const rosSlice = createSlice({
   name: 'ros',
   initialState,
   reducers: {
     updateNamespace: (state, { payload }: PayloadAction<string>) => {
-      state.namespace = payload
+      state.namespace = payload;
     },
     updateIP: (state, { payload }: PayloadAction<string>) => {
-      state.IP = payload
+      state.IP = payload;
     },
     updatePort: (state, { payload }: PayloadAction<string>) => {
-      state.port = payload
+      state.port = payload;
     },
     updateRobotName: (state, { payload }: PayloadAction<string>) => {
-      state.robotName = payload
+      state.robotName = payload;
     },
     updateVideoServerPort: (state, { payload }: PayloadAction<string>) => {
-      state.videoServerPort = payload
+      state.videoServerPort = payload;
     },
     updateDescriptionServerPort: (
       state,
       { payload }: PayloadAction<string>
     ) => {
-      state.descriptionServerPort = payload
+      state.descriptionServerPort = payload;
     },
     updateBaseLinkName: (state, { payload }: PayloadAction<string>) => {
-      state.baseLinkName = payload
+      state.baseLinkName = payload;
     },
   },
-})
+});
 
-export const selectIP = (state: GlobalState): string => state.ros.IP
-export const selectPort = (state: GlobalState): string => state.ros.port
+export const selectIP = (state: GlobalState): string => state.ros.IP;
+export const selectPort = (state: GlobalState): string => state.ros.port;
 export const selectRobotName = (state: GlobalState): string =>
-  state.ros.robotName
+  state.ros.robotName;
 export const selectVideoServerPort = (state: GlobalState): string =>
-  state.ros.videoServerPort
+  state.ros.videoServerPort;
 export const selectDescriptionServerPort = (state: GlobalState): string =>
-  state.ros.descriptionServerPort
+  state.ros.descriptionServerPort;
 export const selectBaseLinkName = (state: GlobalState): string =>
-  state.ros.baseLinkName
+  state.ros.baseLinkName;
 
 export const selectNamespace = (state: GlobalState): string =>
-  state.ros.namespace
+  state.ros.namespace;
 export const selectFullAddress = (state: GlobalState): string =>
-  `${state.ros.IP}:${state.ros.port}/`
+  `${state.ros.IP}:${state.ros.port}/`;
 
 export const selectVideoUrl =
   (camera: ICameraData, param: 'stream' | 'snapshot' = 'stream') =>
   (state: GlobalState): string => {
-    let cameraType = camera.type
+    let cameraType = camera.type;
     // QR Code feeds are streamed as mjpeg
     if (camera.type === CameraType.QR_CODE) {
-      cameraType = CameraType.MJPEG
+      cameraType = CameraType.MJPEG;
     }
 
-    return `http://${state.ros.IP}:${state.ros.videoServerPort}/${param}?topic=${camera.topic}&type=${cameraType}`
-  }
+    return `http://${state.ros.IP}:${state.ros.videoServerPort}/${param}?topic=${camera.topic}&type=${cameraType}`;
+  };

--- a/src/renderer/store/modules/ros.ts
+++ b/src/renderer/store/modules/ros.ts
@@ -36,7 +36,7 @@ export const rosSlice = createSlice({
       state.port = payload
     },
     updateRobotName: (state, { payload }: PayloadAction<string>) => {
-      state.robotName = payload;
+      state.robotName = payload
     },
     updateVideoServerPort: (state, { payload }: PayloadAction<string>) => {
       state.videoServerPort = payload
@@ -55,7 +55,8 @@ export const rosSlice = createSlice({
 
 export const selectIP = (state: GlobalState): string => state.ros.IP
 export const selectPort = (state: GlobalState): string => state.ros.port
-export const selectRobotName = (state: GlobalState): string => state.ros.robotName
+export const selectRobotName = (state: GlobalState): string =>
+  state.ros.robotName
 export const selectVideoServerPort = (state: GlobalState): string =>
   state.ros.videoServerPort
 export const selectDescriptionServerPort = (state: GlobalState): string =>

--- a/src/renderer/store/modules/ros.ts
+++ b/src/renderer/store/modules/ros.ts
@@ -6,6 +6,7 @@ export interface RosState {
   namespace: string
   IP: string
   port: string
+  robotName: string
   videoServerPort: string
   descriptionServerPort: string
   baseLinkName: string
@@ -15,6 +16,7 @@ export const initialState: RosState = {
   namespace: 'capra_ui/',
   IP: 'jetson',
   port: '9090',
+  robotName: 'markhor',
   videoServerPort: '8080',
   descriptionServerPort: '88',
   baseLinkName: 'markhor_link_base',
@@ -33,6 +35,9 @@ export const rosSlice = createSlice({
     updatePort: (state, { payload }: PayloadAction<string>) => {
       state.port = payload
     },
+    updateRobotName: (state, { payload }: PayloadAction<string>) => {
+      state.robotName = payload;
+    },
     updateVideoServerPort: (state, { payload }: PayloadAction<string>) => {
       state.videoServerPort = payload
     },
@@ -50,6 +55,7 @@ export const rosSlice = createSlice({
 
 export const selectIP = (state: GlobalState): string => state.ros.IP
 export const selectPort = (state: GlobalState): string => state.ros.port
+export const selectRobotName = (state: GlobalState): string => state.ros.robotName
 export const selectVideoServerPort = (state: GlobalState): string =>
   state.ros.videoServerPort
 export const selectDescriptionServerPort = (state: GlobalState): string =>


### PR DESCRIPTION
To allow the UI's development to continue without splitting into two versions, I added a field in the "config" to allow the user to enter the current robot's name.
To cover every scenario where 'markhor' was hard-coded, I use both useSelectors and a new selectRobotNameState to read the state, which now includes the robotName field.
The remaining uses of 'markhor' are from initialState arguments.
Some other minor changes include the removal of "dead code" and automatic import clean-ups.