### PR TITLE
Fix Ovis joint velocity message type name

### DIFF
--- a/src/renderer/inputSystem/armModeActions.ts
+++ b/src/renderer/inputSystem/armModeActions.ts
@@ -9,7 +9,7 @@ import { handleTpvControl } from './tpvControl';
 
 const jointGoalTopic: TopicOptions = {
   name: 'ovis/arm/in/joint_velocity_goal',
-  messageType: 'ovis_msgs/OvisArmJointVelocity',
+  messageType: 'ovis_msgs/OvisJointVelocity',
 };
 
 export const armModeActions: Action[] = [


### PR DESCRIPTION
The old message type name used is outdated. The message type name has been changed to OvisJointVelocity in the Ovis repo.