### PR TITLE
Limit the gamepad publish rate to 20Hz

### DIFF
--- a/src/renderer/inputSystem/InputSystem.ts
+++ b/src/renderer/inputSystem/InputSystem.ts
@@ -11,7 +11,8 @@ import {
   GamepadButtonBinding,
 } from '@/renderer/inputSystem/@types';
 
-const GAMEPAD_REFRESH_RATE = 20;
+// 1000ms / refresh rate in Hz
+const GAMEPAD_REFRESH_RATE = 1000 / 20;
 
 /* TODO
  * - button axis (RT, LT)
@@ -98,7 +99,7 @@ export class InputSystem {
       setTimeout(() => {
         this.updateGamepad();
         requestAnimationFrame(this.update);
-      }, 1000 / GAMEPAD_REFRESH_RATE);
+      }, GAMEPAD_REFRESH_RATE);
     }
   };
 

--- a/src/renderer/inputSystem/InputSystem.ts
+++ b/src/renderer/inputSystem/InputSystem.ts
@@ -11,7 +11,7 @@ import {
   GamepadButtonBinding,
 } from '@/renderer/inputSystem/@types';
 
-const GAMEPAD_REFRESH_RATE = 10;
+const GAMEPAD_REFRESH_RATE = 20;
 
 /* TODO
  * - button axis (RT, LT)

--- a/src/renderer/inputSystem/InputSystem.ts
+++ b/src/renderer/inputSystem/InputSystem.ts
@@ -11,6 +11,8 @@ import {
   GamepadButtonBinding,
 } from '@/renderer/inputSystem/@types';
 
+const GAMEPAD_REFRESH_RATE = 10;
+
 /* TODO
  * - button axis (RT, LT)
  * - support key combinations?
@@ -93,8 +95,10 @@ export class InputSystem {
 
   private update = () => {
     if (this.isRunning) {
-      this.updateGamepad();
-      requestAnimationFrame(this.update);
+      setTimeout(() => {
+        this.updateGamepad();
+        requestAnimationFrame(this.update);
+      }, 1000 / GAMEPAD_REFRESH_RATE);
     }
   };
 


### PR DESCRIPTION
Previously the gamepad refresh rate would cause the joy messages to be publish at a rate of the computer screen's refresh rate. So on higher refresh rate screens this would cause higher latency on the commands. The publish rate is now limited to 20Hz instead of the screen's refresh rate to use less bandwidth.