### PR TITLE
Add GPIO control buttons to turn on and off the lights

### DIFF
--- a/src/renderer/components/common/Button.tsx
+++ b/src/renderer/components/common/Button.tsx
@@ -55,6 +55,7 @@ const StyledButton = styled.button<StyledButtonProps>`
     ${({ theme }) => theme.colors.background},
     ${({ theme }) => theme.colors.darkerBackground}
   );
+  border-radius: 4px;
 
   &:hover {
     background-image: linear-gradient(

--- a/src/renderer/components/common/IconButton.tsx
+++ b/src/renderer/components/common/IconButton.tsx
@@ -1,0 +1,43 @@
+import { styled } from '@/renderer/globalStyles/styled';
+import React, { ReactNode } from 'react';
+
+interface IconButtonProps {
+  icon: ReactNode;
+  onClick: () => void;
+  title?: string;
+  style?: React.CSSProperties;
+}
+
+const IconContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+`;
+
+const Button = styled.button`
+  background-color: ${({ theme }) => theme.colors.darkerBackground};
+  border-radius: 4px;
+  padding: 6px;
+  color: white;
+  border: none;
+  background: linear-gradient(#0000, rgb(0 0 0/30%)) top/100% 800%;
+  transition: background-position 0.2s ease-in-out;
+
+  &:hover {
+    background-position: bottom;
+  }
+`;
+
+const IconButton = ({ icon, onClick, title, style }: IconButtonProps) => {
+  return (
+    <Button style={style} onClick={onClick}>
+      <IconContainer>
+        {icon}
+        {title && <span style={{ marginLeft: '4px' }}>{title}</span>}
+      </IconContainer>
+    </Button>
+  );
+};
+
+export default IconButton;

--- a/src/renderer/components/pages/Config/ConfigMenu.tsx
+++ b/src/renderer/components/pages/Config/ConfigMenu.tsx
@@ -20,6 +20,9 @@ export const ConfigMenu: FC = () => {
           <StyledNavLink to="/config/armPresets">Arm Presets</StyledNavLink>
         </li>
         <li>
+          <StyledNavLink to="/config/gpioPins">GPIO Control</StyledNavLink>
+        </li>
+        <li>
           <StyledNavLink to="/config/gamepad">Gamepad</StyledNavLink>
         </li>
         <li>

--- a/src/renderer/components/pages/Config/ConfigPage.tsx
+++ b/src/renderer/components/pages/Config/ConfigPage.tsx
@@ -6,8 +6,9 @@ import { CameraConfig } from '@/renderer/components/pages/Config/pages/CameraCon
 import { GamepadConfig } from '@/renderer/components/pages/Config/pages/GamepadConfig';
 import { GraphConfig } from '@/renderer/components/pages/Config/pages/GraphConfig/GraphConfig';
 import { styled } from '@/renderer/globalStyles/styled';
-import { LaunchConfig } from './pages/LaunchConfig/LaunchConfig';
-import ArmPresetsConfig from './pages/ArmPresetsConfig/ArmPresetsConfig';
+import { LaunchConfig } from '@/renderer/components/pages/Config/pages/LaunchConfig/LaunchConfig';
+import ArmPresetsConfig from '@/renderer/components/pages/Config/pages/ArmPresetsConfig/ArmPresetsConfig';
+import { GpioPinsConfig } from '@/renderer/components/pages/Config/pages/GpioPinsConfig/GpioPinsConfig';
 
 export const ConfigPage: FC = () => {
   return (
@@ -22,6 +23,7 @@ export const ConfigPage: FC = () => {
           <Route path="/camera" element={<CameraConfig />} />
           <Route path="/graph" element={<GraphConfig />} />
           <Route path="/armPresets" element={<ArmPresetsConfig />} />
+          <Route path="/gpioPins" element={<GpioPinsConfig />} />
           <Route path="/gamepad" element={<GamepadConfig />} />
           <Route path="/launch" element={<LaunchConfig />} />
         </Routes>

--- a/src/renderer/components/pages/Config/pages/GpioPinsConfig/GpioPin.tsx
+++ b/src/renderer/components/pages/Config/pages/GpioPinsConfig/GpioPin.tsx
@@ -1,9 +1,6 @@
 import IconButton from '@/renderer/components/common/IconButton';
 import { styled } from '@/renderer/globalStyles/styled';
-import {
-  GpioPinsState,
-  gpioPinsSlice,
-} from '@/renderer/store/modules/gpioPins';
+import { GpioPinState, gpioPinsSlice } from '@/renderer/store/modules/gpioPins';
 import { rosClient } from '@/renderer/utils/ros/rosClient';
 import { TopicOptions } from '@/renderer/utils/ros/roslib-ts-client/@types';
 import React, { useMemo } from 'react';
@@ -11,7 +8,7 @@ import { FaPowerOff } from 'react-icons/fa';
 import { useDispatch } from 'react-redux';
 
 interface GpioPinProps {
-  gpioPin: GpioPinsState;
+  gpioPin: GpioPinState;
 }
 
 const Card = styled.div`

--- a/src/renderer/components/pages/Config/pages/GpioPinsConfig/GpioPin.tsx
+++ b/src/renderer/components/pages/Config/pages/GpioPinsConfig/GpioPin.tsx
@@ -1,8 +1,15 @@
 import IconButton from '@/renderer/components/common/IconButton';
 import { styled } from '@/renderer/globalStyles/styled';
-import { GpioPinsState } from '@/renderer/store/modules/gpioPins';
-import React from 'react';
+import { useRosSubscribe } from '@/renderer/hooks/useRosSubscribe';
+import {
+  GpioPinsState,
+  gpioPinsSlice,
+} from '@/renderer/store/modules/gpioPins';
+import { rosClient } from '@/renderer/utils/ros/rosClient';
+import { TopicOptions } from '@/renderer/utils/ros/roslib-ts-client/@types';
+import React, { useMemo } from 'react';
 import { FaPowerOff } from 'react-icons/fa';
+import { useDispatch } from 'react-redux';
 
 interface GpioPinProps {
   gpioPin: GpioPinsState;
@@ -23,13 +30,35 @@ const Card = styled.div`
 `;
 
 export const GpioPin = ({ gpioPin }: GpioPinProps) => {
+  const dispatch = useDispatch();
+
+  const topic: TopicOptions = useMemo(
+    () => ({
+      name: gpioPin.topicName,
+      messageType: 'std_msgs/Float32',
+    }),
+    [gpioPin.topicName]
+  );
+
+  const togglePin = () => {
+    rosClient.publish(topic, gpioPin.isOn ? 0 : 1);
+
+    dispatch(gpioPinsSlice.actions.togglePin(gpioPin.id));
+  };
+
+  useRosSubscribe(topic, (message) => {
+    dispatch(
+      gpioPinsSlice.actions.updatePin({ ...gpioPin, isOn: !!message.data })
+    );
+  });
+
   return (
     <Card>
-      <h3>{gpioPin.name}</h3>
+      <h3 style={{ paddingBottom: '4px' }}>{gpioPin.name}</h3>
       <IconButton
         icon={<FaPowerOff />}
         title={gpioPin.isOn ? 'Power Off' : 'Power On'}
-        onClick={() => {}}
+        onClick={togglePin}
         style={
           gpioPin.isOn
             ? { backgroundColor: 'red' }

--- a/src/renderer/components/pages/Config/pages/GpioPinsConfig/GpioPin.tsx
+++ b/src/renderer/components/pages/Config/pages/GpioPinsConfig/GpioPin.tsx
@@ -1,13 +1,12 @@
 import IconButton from '@/renderer/components/common/IconButton';
 import { styled } from '@/renderer/globalStyles/styled';
-import { useRosSubscribe } from '@/renderer/hooks/useRosSubscribe';
 import {
   GpioPinsState,
   gpioPinsSlice,
 } from '@/renderer/store/modules/gpioPins';
 import { rosClient } from '@/renderer/utils/ros/rosClient';
 import { TopicOptions } from '@/renderer/utils/ros/roslib-ts-client/@types';
-import React, { useCallback, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { FaPowerOff } from 'react-icons/fa';
 import { useDispatch } from 'react-redux';
 
@@ -26,7 +25,6 @@ const Card = styled.div`
   justify-content: flex-start;
   align-items: flex-start;
   box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.5);
-  transition: box-shadow 0.2s ease-in-out;
 `;
 
 export const GpioPin = ({ gpioPin }: GpioPinProps) => {
@@ -45,21 +43,6 @@ export const GpioPin = ({ gpioPin }: GpioPinProps) => {
 
     dispatch(gpioPinsSlice.actions.togglePin(gpioPin.id));
   };
-
-  useRosSubscribe(
-    topic,
-    useCallback(
-      (message) => () => {
-        dispatch(
-          gpioPinsSlice.actions.updateIsOn({
-            id: gpioPin.id,
-            isOn: !!message.data,
-          })
-        );
-      },
-      [dispatch, gpioPin.id]
-    )
-  );
 
   return (
     <Card>

--- a/src/renderer/components/pages/Config/pages/GpioPinsConfig/GpioPin.tsx
+++ b/src/renderer/components/pages/Config/pages/GpioPinsConfig/GpioPin.tsx
@@ -1,0 +1,29 @@
+import { styled } from '@/renderer/globalStyles/styled';
+import { GpioPinsState } from '@/renderer/store/modules/gpioPins';
+import React from 'react';
+
+interface GpioPinProps {
+  gpioPin: GpioPinsState;
+}
+
+const Card = styled.div`
+  background-color: ${({ theme }) => theme.colors.darkerBackground};
+  border-radius: 4px;
+  padding: 16px;
+  margin: 8px;
+  display: flex;
+  min-width: 300px;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: flex-start;
+  box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.5);
+  transition: box-shadow 0.2s ease-in-out;
+`;
+
+export const GpioPin = ({ gpioPin }: GpioPinProps) => {
+  return (
+    <Card>
+      <h3>{gpioPin.name}</h3>
+    </Card>
+  );
+};

--- a/src/renderer/components/pages/Config/pages/GpioPinsConfig/GpioPin.tsx
+++ b/src/renderer/components/pages/Config/pages/GpioPinsConfig/GpioPin.tsx
@@ -1,6 +1,8 @@
+import IconButton from '@/renderer/components/common/IconButton';
 import { styled } from '@/renderer/globalStyles/styled';
 import { GpioPinsState } from '@/renderer/store/modules/gpioPins';
 import React from 'react';
+import { FaPowerOff } from 'react-icons/fa';
 
 interface GpioPinProps {
   gpioPin: GpioPinsState;
@@ -11,8 +13,8 @@ const Card = styled.div`
   border-radius: 4px;
   padding: 16px;
   margin: 8px;
+  min-width: 150px;
   display: flex;
-  min-width: 300px;
   flex-direction: column;
   justify-content: flex-start;
   align-items: flex-start;
@@ -24,6 +26,16 @@ export const GpioPin = ({ gpioPin }: GpioPinProps) => {
   return (
     <Card>
       <h3>{gpioPin.name}</h3>
+      <IconButton
+        icon={<FaPowerOff />}
+        title={gpioPin.isOn ? 'Power Off' : 'Power On'}
+        onClick={() => {}}
+        style={
+          gpioPin.isOn
+            ? { backgroundColor: 'red' }
+            : { backgroundColor: 'green' }
+        }
+      />
     </Card>
   );
 };

--- a/src/renderer/components/pages/Config/pages/GpioPinsConfig/GpioPinsConfig.tsx
+++ b/src/renderer/components/pages/Config/pages/GpioPinsConfig/GpioPinsConfig.tsx
@@ -2,13 +2,26 @@ import React from 'react';
 import { SectionTitle } from '../../styles';
 import { useDispatch, useSelector } from 'react-redux';
 import { selectAllGpioPins } from '@/renderer/store/modules/gpioPins';
+import { GpioPin } from './GpioPin';
+import { styled } from '@/renderer/globalStyles/styled';
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+`;
 
 export const GpioPinsConfig = () => {
   const dispatch = useDispatch();
   const gpioPins = useSelector(selectAllGpioPins);
   return (
     <div>
-      <SectionTitle>GPIO Config</SectionTitle>
+      <SectionTitle>GPIO Control</SectionTitle>
+      <Container>
+        {gpioPins.map((gpioPin) => (
+          <GpioPin key={gpioPin.id} gpioPin={gpioPin} />
+        ))}
+      </Container>
     </div>
   );
 };

--- a/src/renderer/components/pages/Config/pages/GpioPinsConfig/GpioPinsConfig.tsx
+++ b/src/renderer/components/pages/Config/pages/GpioPinsConfig/GpioPinsConfig.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { SectionTitle } from '../../styles';
+import { useDispatch, useSelector } from 'react-redux';
+import { selectAllGpioPins } from '@/renderer/store/modules/gpioPins';
+
+export const GpioPinsConfig = () => {
+  const dispatch = useDispatch();
+  const gpioPins = useSelector(selectAllGpioPins);
+  return (
+    <div>
+      <SectionTitle>GPIO Config</SectionTitle>
+    </div>
+  );
+};

--- a/src/renderer/components/pages/Config/pages/GpioPinsConfig/GpioPinsConfig.tsx
+++ b/src/renderer/components/pages/Config/pages/GpioPinsConfig/GpioPinsConfig.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { SectionTitle } from '../../styles';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { selectAllGpioPins } from '@/renderer/store/modules/gpioPins';
 import { GpioPin } from './GpioPin';
 import { styled } from '@/renderer/globalStyles/styled';
@@ -12,16 +12,15 @@ const Container = styled.div`
 `;
 
 export const GpioPinsConfig = () => {
-  const dispatch = useDispatch();
   const gpioPins = useSelector(selectAllGpioPins);
   return (
-    <div>
+    <>
       <SectionTitle>GPIO Control</SectionTitle>
       <Container>
         {gpioPins.map((gpioPin) => (
           <GpioPin key={gpioPin.id} gpioPin={gpioPin} />
         ))}
       </Container>
-    </div>
+    </>
   );
 };

--- a/src/renderer/store/localStorage.ts
+++ b/src/renderer/store/localStorage.ts
@@ -6,6 +6,7 @@ import { initialState as inputState } from '@/renderer/store/modules/input';
 import { initialState as debugTabState } from '@/renderer/store/modules/debugTab';
 import { initialState as launchFilesState } from '@/renderer/store/modules/launchFiles';
 import { initialState as armPresetsState } from '@/renderer/store/modules/armPresets';
+import { initialState as gpioPinsState } from '@/renderer/store/modules/gpioPins';
 import { log } from '@/renderer/logger';
 
 export const defaultState: GlobalState = {
@@ -15,6 +16,7 @@ export const defaultState: GlobalState = {
   debugTab: debugTabState,
   launchFiles: launchFilesState,
   armPresets: armPresetsState,
+  gpioPins: gpioPinsState,
 };
 
 // WARN

--- a/src/renderer/store/modules/gpioPins.ts
+++ b/src/renderer/store/modules/gpioPins.ts
@@ -43,10 +43,17 @@ export const gpioPinsSlice = createSlice({
     addPin: (state, { payload }: PayloadAction<GpioPinsState>) => {
       state.push(payload);
     },
+    updatePin: (state, { payload }: PayloadAction<GpioPinsState>) => {
+      const element = state.find((element) => element.id === payload.id);
+      if (element) {
+        element.name = payload.name;
+        element.topicName = payload.topicName;
+      }
+    },
     removePin: (state, { payload }: PayloadAction<GpioPinsState>) => {
       state = state.filter((pin) => pin.id !== payload.id);
     },
   },
 });
 
-export const selectAllPins = (state: GlobalState) => state.gpioPins;
+export const selectAllGpioPins = (state: GlobalState) => state.gpioPins;

--- a/src/renderer/store/modules/gpioPins.ts
+++ b/src/renderer/store/modules/gpioPins.ts
@@ -12,19 +12,19 @@ export interface GpioPinsState {
 export const initialState: GpioPinsState[] = [
   {
     id: nanoid(),
-    name: 'LED 1',
+    name: 'FRONT LED',
     topicName: '/DOP1',
     isOn: false,
   },
   {
     id: nanoid(),
-    name: 'LED 2',
+    name: 'BACK LED',
     topicName: '/DOP2',
     isOn: false,
   },
   {
     id: nanoid(),
-    name: 'LED 3',
+    name: 'ARM LED',
     topicName: '/DOP3',
     isOn: false,
   },

--- a/src/renderer/store/modules/gpioPins.ts
+++ b/src/renderer/store/modules/gpioPins.ts
@@ -13,19 +13,19 @@ export const initialState: GpioPinsState[] = [
   {
     id: nanoid(),
     name: 'LED 1',
-    topicName: '',
+    topicName: '/DOP1',
     isOn: false,
   },
   {
     id: nanoid(),
     name: 'LED 2',
-    topicName: '',
+    topicName: '/DOP2',
     isOn: false,
   },
   {
     id: nanoid(),
     name: 'LED 3',
-    topicName: '',
+    topicName: '/DOP3',
     isOn: false,
   },
 ];
@@ -48,6 +48,15 @@ export const gpioPinsSlice = createSlice({
       if (element) {
         element.name = payload.name;
         element.topicName = payload.topicName;
+      }
+    },
+    updateIsOn: (
+      state,
+      { payload }: PayloadAction<{ id: string; isOn: boolean }>
+    ) => {
+      const element = state.find((element) => element.id === payload.id);
+      if (element) {
+        element.isOn = payload.isOn;
       }
     },
     removePin: (state, { payload }: PayloadAction<GpioPinsState>) => {

--- a/src/renderer/store/modules/gpioPins.ts
+++ b/src/renderer/store/modules/gpioPins.ts
@@ -1,0 +1,52 @@
+import { GlobalState } from '@/renderer/store/store';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { nanoid } from 'nanoid';
+
+export interface GpioPinsState {
+  id: string;
+  name: string;
+  topicName: string;
+  isOn: boolean;
+}
+
+export const initialState: GpioPinsState[] = [
+  {
+    id: nanoid(),
+    name: 'LED 1',
+    topicName: '',
+    isOn: false,
+  },
+  {
+    id: nanoid(),
+    name: 'LED 2',
+    topicName: '',
+    isOn: false,
+  },
+  {
+    id: nanoid(),
+    name: 'LED 3',
+    topicName: '',
+    isOn: false,
+  },
+];
+
+export const gpioPinsSlice = createSlice({
+  name: 'gpioPins',
+  initialState,
+  reducers: {
+    togglePin: (state, { payload }: PayloadAction<string>) => {
+      const element = state.find((element) => element.id === payload);
+      if (element) {
+        element.isOn = !element.isOn;
+      }
+    },
+    addPin: (state, { payload }: PayloadAction<GpioPinsState>) => {
+      state.push(payload);
+    },
+    removePin: (state, { payload }: PayloadAction<GpioPinsState>) => {
+      state = state.filter((pin) => pin.id !== payload.id);
+    },
+  },
+});
+
+export const selectAllPins = (state: GlobalState) => state.gpioPins;

--- a/src/renderer/store/modules/gpioPins.ts
+++ b/src/renderer/store/modules/gpioPins.ts
@@ -2,14 +2,14 @@ import { GlobalState } from '@/renderer/store/store';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { nanoid } from 'nanoid';
 
-export interface GpioPinsState {
+export interface GpioPinState {
   id: string;
   name: string;
   topicName: string;
   isOn: boolean;
 }
 
-export const initialState: GpioPinsState[] = [
+export const initialState: GpioPinState[] = [
   {
     id: nanoid(),
     name: 'FRONT LED',
@@ -40,10 +40,10 @@ export const gpioPinsSlice = createSlice({
         element.isOn = !element.isOn;
       }
     },
-    addPin: (state, { payload }: PayloadAction<GpioPinsState>) => {
+    addPin: (state, { payload }: PayloadAction<GpioPinState>) => {
       state.push(payload);
     },
-    updatePin: (state, { payload }: PayloadAction<GpioPinsState>) => {
+    updatePin: (state, { payload }: PayloadAction<GpioPinState>) => {
       const element = state.find((element) => element.id === payload.id);
       if (element) {
         element.name = payload.name;
@@ -59,7 +59,7 @@ export const gpioPinsSlice = createSlice({
         element.isOn = payload.isOn;
       }
     },
-    removePin: (state, { payload }: PayloadAction<GpioPinsState>) => {
+    removePin: (state, { payload }: PayloadAction<GpioPinState>) => {
       state = state.filter((pin) => pin.id !== payload.id);
     },
   },

--- a/src/renderer/store/store.ts
+++ b/src/renderer/store/store.ts
@@ -11,6 +11,7 @@ import { configureStore, AnyAction, combineReducers } from '@reduxjs/toolkit';
 import { throttle } from 'lodash';
 import { launchFilesSlice } from './modules/launchFiles';
 import { armPresetsSlice } from './modules/armPresets';
+import { gpioPinsSlice } from './modules/gpioPins';
 
 const appReducer = combineReducers({
   feed: feedSlice.reducer,
@@ -19,6 +20,7 @@ const appReducer = combineReducers({
   debugTab: debugTabSlice.reducer,
   launchFiles: launchFilesSlice.reducer,
   armPresets: armPresetsSlice.reducer,
+  gpioPins: gpioPinsSlice.reducer,
 });
 
 export type GlobalState = ReturnType<typeof appReducer>;


### PR DESCRIPTION
This PR adds a new config menu to control our lights. These are not customizable directly in the UI for now, this feature can be added in another PR. 
<img width="1279" alt="image" src="https://github.com/clubcapra/capra_web_ui/assets/46896242/73117489-a3d1-462c-a00c-9ba93906dacf">
